### PR TITLE
Adds test to only the example project plugin

### DIFF
--- a/4.19/ExampleProject/Plugins/PlayFab/Source/PlayFab/PlayFab.Build.cs
+++ b/4.19/ExampleProject/Plugins/PlayFab/Source/PlayFab/PlayFab.Build.cs
@@ -29,6 +29,12 @@ namespace UnrealBuildTool.Rules
                     "PlayFabCommon"
                 }
             );
+            PrivateDependencyModuleNames.AddRange(
+                new string[]
+                {
+                    "PlayFabTests"
+                }
+            );
         }
     }
 }

--- a/4.20/ExampleProject/Plugins/PlayFab/Source/PlayFab/PlayFab.Build.cs
+++ b/4.20/ExampleProject/Plugins/PlayFab/Source/PlayFab/PlayFab.Build.cs
@@ -29,6 +29,12 @@ namespace UnrealBuildTool.Rules
                     "PlayFabCommon"
                 }
             );
+            PrivateDependencyModuleNames.AddRange(
+                new string[]
+                {
+                    "PlayFabTests"
+                }
+            );
         }
     }
 }

--- a/4.21/ExampleProject/Plugins/PlayFab/Source/PlayFab/PlayFab.Build.cs
+++ b/4.21/ExampleProject/Plugins/PlayFab/Source/PlayFab/PlayFab.Build.cs
@@ -29,6 +29,12 @@ namespace UnrealBuildTool.Rules
                     "PlayFabCommon"
                 }
             );
+            PrivateDependencyModuleNames.AddRange(
+                new string[]
+                {
+                    "PlayFabTests"
+                }
+            );
         }
     }
 }


### PR DESCRIPTION
This can't be the correct fix, we need to pull this into SDKGenerator without the need for it to be in the /Plugin/ folder