### PR TITLE
Threading support for WriteTitleEvents

### DIFF
--- a/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCommon/Public/PlayFabAuthenticationContext.h
+++ b/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCommon/Public/PlayFabAuthenticationContext.h
@@ -92,7 +92,7 @@ public:
     UFUNCTION(BlueprintCallable, BlueprintPure, Category = "PlayFab | Core")
         FString& GetDeveloperSecretKey()
     {
-#if defined(ENABLE_PLAYFABSERVER_API) && defined(ENABLE_PLAYFABADMIN_API)
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
         return DeveloperSecretKey;
 #endif
 
@@ -103,7 +103,7 @@ public:
     // Get the developer secret key. These keys can be used in development environments.
     const FString& GetDeveloperSecretKey() const
     {
-#if defined(ENABLE_PLAYFABSERVER_API) && defined(ENABLE_PLAYFABADMIN_API)
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
         return DeveloperSecretKey;
 #endif
 
@@ -115,7 +115,7 @@ public:
     UFUNCTION(BlueprintCallable, Category = "PlayFab | Core")
         void SetDeveloperSecretKey(FString InKey)
     { 
-#if defined(ENABLE_PLAYFABSERVER_API) && defined(ENABLE_PLAYFABADMIN_API)
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
         DeveloperSecretKey = MoveTemp(InKey);
         return;
 #endif

--- a/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCommon/Public/PlayFabCommonSettings.h
+++ b/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCommon/Public/PlayFabCommonSettings.h
@@ -9,7 +9,7 @@
 
 namespace PlayFabCommon
 {
-    class PlayFabCommonSettings
+    class PLAYFABCOMMON_API PlayFabCommonSettings
     {
     public:
         static const FString sdkVersion;

--- a/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabClientAPI.cpp
+++ b/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabClientAPI.cpp
@@ -5031,7 +5031,7 @@ bool UPlayFabClientAPI::WriteTitleEvent(
     }
 
 
-    auto HttpRequest = PlayFabRequestHandler::SendRequest(PlayFabSettings::GetUrl(TEXT("/Client/WriteTitleEvent")), request.toJSONString(), TEXT("X-Authorization"), !request.AuthenticationContext.IsValid() ? PlayFabSettings::GetClientSessionTicket() : request.AuthenticationContext->GetClientSessionTicket());
+    auto HttpRequest = PlayFabRequestHandler::SendRequest(PlayFabCommon::PlayFabCommonSettings::getURL(TEXT("/Client/WriteTitleEvent")), request.toJSONString(), TEXT("X-Authorization"), !request.AuthenticationContext.IsValid() ? PlayFabSettings::GetClientSessionTicket() : request.AuthenticationContext->GetClientSessionTicket());
     HttpRequest->OnProcessRequestComplete().BindRaw(this, &UPlayFabClientAPI::OnWriteTitleEventResult, SuccessDelegate, ErrorDelegate);
     return HttpRequest->ProcessRequest();
 }

--- a/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabResultHandler.cpp
+++ b/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabResultHandler.cpp
@@ -18,8 +18,8 @@ int PlayFabRequestHandler::GetPendingCalls()
 
 TSharedRef<IHttpRequest> PlayFabRequestHandler::SendRequest(const FString& url, const FString& callBody, const FString& authKey, const FString& authValue)
 {
-    if (PlayFabSettings::GetTitleId().Len() == 0) {
-        UE_LOG(LogPlayFabCpp, Error, TEXT("You must define a titleID before making API Calls."));
+    if (PlayFabCommon::PlayFabCommonSettings::titleId.Len() == 0) {
+        UE_LOG(LogPlayFabCpp, Error, TEXT("You must call SetTitleID before making API Calls."));
     }
     PlayFabRequestHandler::pendingCalls += 1;
 

--- a/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabServerAPI.cpp
+++ b/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabServerAPI.cpp
@@ -3873,7 +3873,7 @@ bool UPlayFabServerAPI::WriteTitleEvent(
     }
 
 
-    auto HttpRequest = PlayFabRequestHandler::SendRequest(PlayFabSettings::GetUrl(TEXT("/Server/WriteTitleEvent")), request.toJSONString(), TEXT("X-SecretKey"), !request.AuthenticationContext.IsValid() ? PlayFabSettings::GetDeveloperSecretKey() : request.AuthenticationContext->GetDeveloperSecretKey());
+    auto HttpRequest = PlayFabRequestHandler::SendRequest(PlayFabCommon::PlayFabCommonSettings::getURL(TEXT("/Server/WriteTitleEvent")), request.toJSONString(), TEXT("X-SecretKey"), !request.AuthenticationContext.IsValid() ? PlayFabSettings::GetDeveloperSecretKey() : request.AuthenticationContext->GetDeveloperSecretKey());
     HttpRequest->OnProcessRequestComplete().BindRaw(this, &UPlayFabServerAPI::OnWriteTitleEventResult, SuccessDelegate, ErrorDelegate);
     return HttpRequest->ProcessRequest();
 }


### PR DESCRIPTION
Support for Writing Title Events from a thread (providing you call SetTitleID on the API and provide an AuthenticationContext). Also support for DeveloperSecretKey access on AuthenticationContext by only providing one define.