### PR TITLE
Fix build log spam

### DIFF
--- a/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCommon/PlayFabCommon.Build.cs
+++ b/4.22/PlayFabPlugin/PlayFab/Source/PlayFabCommon/PlayFabCommon.Build.cs
@@ -36,7 +36,6 @@ public class PlayFabCommon : ModuleRules
 
         BuildVersion Version;
         BuildVersion.TryRead(BuildVersion.GetDefaultFileName(), out Version);
-        System.Console.WriteLine("MAJOR VERSION {0} MINOR VERSION {1}", Version.MajorVersion, Version.MinorVersion);
         PublicDefinitions.Add(string.Format("ENGINE_MAJOR_VERSION={0}", Version.MajorVersion));
         PublicDefinitions.Add(string.Format("ENGINE_MINOR_VERSION={0}", Version.MinorVersion));
 


### PR DESCRIPTION
Remove log from build.cs to stop logs when building and generating project files