### PR TITLE
Update BuildWin64.bat

### DIFF
--- a/4.25/ExampleProject/BuildWin64.bat
+++ b/4.25/ExampleProject/BuildWin64.bat
@@ -17,6 +17,6 @@ set archivePath=Build\%targetPlatform%
 
 
 rem # The actual build command. To adapt depending on the needs.
-call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile -SkipBuildPatchPrereq
 
 


### PR DESCRIPTION
skipping build patch prereq. 4.25 added this in but it doesn't compile for our build system.

To install the prereq, we need to be able to launch the editor, which we can't do on our current devices.