### PR TITLE
Fixed an issue where PLAYFABCPP_API on a template created linker issues

### DIFF
--- a/4.23/ExampleProject/Plugins/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
+++ b/4.23/ExampleProject/Plugins/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
@@ -19,7 +19,7 @@ namespace PlayFab
     typedef TSharedRef< TJsonReader<TCHAR> > JsonReader;
 
     template <typename BoxedType>
-    class PLAYFABCPP_API Boxed
+    class Boxed
     {
     public:
         BoxedType mValue;

--- a/4.23/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
+++ b/4.23/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
@@ -19,7 +19,7 @@ namespace PlayFab
     typedef TSharedRef< TJsonReader<TCHAR> > JsonReader;
 
     template <typename BoxedType>
-    class PLAYFABCPP_API Boxed
+    class Boxed
     {
     public:
         BoxedType mValue;

--- a/4.24/ExampleProject/Plugins/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
+++ b/4.24/ExampleProject/Plugins/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
@@ -19,7 +19,7 @@ namespace PlayFab
     typedef TSharedRef< TJsonReader<TCHAR> > JsonReader;
 
     template <typename BoxedType>
-    class PLAYFABCPP_API Boxed
+    class Boxed
     {
     public:
         BoxedType mValue;

--- a/4.24/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
+++ b/4.24/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
@@ -19,7 +19,7 @@ namespace PlayFab
     typedef TSharedRef< TJsonReader<TCHAR> > JsonReader;
 
     template <typename BoxedType>
-    class PLAYFABCPP_API Boxed
+    class Boxed
     {
     public:
         BoxedType mValue;

--- a/4.25/ExampleProject/Plugins/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
+++ b/4.25/ExampleProject/Plugins/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
@@ -19,7 +19,7 @@ namespace PlayFab
     typedef TSharedRef< TJsonReader<TCHAR> > JsonReader;
 
     template <typename BoxedType>
-    class PLAYFABCPP_API Boxed
+    class Boxed
     {
     public:
         BoxedType mValue;

--- a/4.25/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
+++ b/4.25/PlayFabPlugin/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h
@@ -19,7 +19,7 @@ namespace PlayFab
     typedef TSharedRef< TJsonReader<TCHAR> > JsonReader;
 
     template <typename BoxedType>
-    class PLAYFABCPP_API Boxed
+    class Boxed
     {
     public:
         BoxedType mValue;

--- a/template/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h.ejs
+++ b/template/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h.ejs
@@ -16,7 +16,7 @@ namespace PlayFab
     typedef TSharedRef< TJsonReader<TCHAR> > JsonReader;
 
     template <typename BoxedType>
-    class PLAYFABCPP_API Boxed
+    class Boxed
     {
     public:
         BoxedType mValue;


### PR DESCRIPTION
Changed template class Boxed to not use the PLAYFABCPP_API import/export macro

 -> This can cause Linker errors when building with visual studio
 -> There is no real reason to export the symbols for a template class

Removing it in Unreal fixed the problem for us. Note that we build Unreal ourselves and do not rely on the binaries provided by Epic, so this case is not tested.