### PR TITLE
Tb/fix auth copy

### DIFF
--- a/4.26/ExampleProject/Plugins/PlayFab/PlayFab.uplugin
+++ b/4.26/ExampleProject/Plugins/PlayFab/PlayFab.uplugin
@@ -2,7 +2,7 @@
     "FileVersion": 3,
     "FriendlyName": "PlayFab Marketplace Plugin",
     "Version": 0,
-    "EngineVersion": "4.26.0",
+    "EngineVersion": "4.26",
     "VersionName": "1.59.210521",
     "CreatedBy": "PlayFab and Phoenix Labs",
     "CreatedByURL": "https://playfab.com/",

--- a/4.26/PlayFabPlugin/PlayFab/PlayFab.uplugin
+++ b/4.26/PlayFabPlugin/PlayFab/PlayFab.uplugin
@@ -2,7 +2,7 @@
     "FileVersion": 3,
     "FriendlyName": "PlayFab Marketplace Plugin",
     "Version": 0,
-    "EngineVersion": "4.26.0",
+    "EngineVersion": "4.26",
     "VersionName": "1.59.210521",
     "CreatedBy": "PlayFab and Phoenix Labs",
     "CreatedByURL": "https://playfab.com/",

--- a/template/templates/PlayFabCpp/core/PlayFab_DataModels.h.ejs
+++ b/template/templates/PlayFabCpp/core/PlayFab_DataModels.h.ejs
@@ -31,10 +31,7 @@ namespace <%- api.name %>Models
             <%- getPropertySafeName(property) %>(<%- getPropertyDefaultValue(api, datatype, property) %>)<% } %>
             {}
 
-        F<%- datatype.name %>(const F<%- datatype.name %>& src) :
-            <%- getBaseType(datatype) %>(src)<% for(var i in datatype.properties) { var property = datatype.properties[i] %>,
-            <%- getPropertySafeName(property) %>(<%- getPropertyCopyValue(property) %>)<% } %>
-            {}
+        F<%- datatype.name %>(const F<%- datatype.name %>& src) = default;
 
         F<%- datatype.name %>(const TSharedPtr<FJsonObject>& obj) : F<%- datatype.name %>()
         {

--- a/template/templates/PlayFabCpp/core/PlayFab_DataModels.h.ejs
+++ b/template/templates/PlayFabCpp/core/PlayFab_DataModels.h.ejs
@@ -32,7 +32,7 @@ namespace <%- api.name %>Models
             {}
 
         F<%- datatype.name %>(const F<%- datatype.name %>& src) :
-            <%- getBaseType(datatype) %>()<% for(var i in datatype.properties) { var property = datatype.properties[i] %>,
+            <%- getBaseType(datatype) %>(src)<% for(var i in datatype.properties) { var property = datatype.properties[i] %>,
             <%- getPropertySafeName(property) %>(<%- getPropertyCopyValue(property) %>)<% } %>
             {}
 


### PR DESCRIPTION
Rare has pointed out our copy constructor was not passing in the src ref object. This prevented the AuthenticationContext in the underlying common object member variables to not be passed along. 

This change forces that copy constructor to work in a default/appropriate manner that the compiler should be able to figure out for us.