### PR TITLE
Update PlayFabCppBaseModel.cpp.ejs

### DIFF
--- a/template/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabCppBaseModel.cpp.ejs
+++ b/template/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabCppBaseModel.cpp.ejs
@@ -95,7 +95,8 @@ FDateTime PlayFab::readDatetime(const TSharedPtr<FJsonValue>& value)
     FString DateString = value->AsString();
     if (!FDateTime::ParseIso8601(*DateString, DateTimeOut))
     {
-        UE_LOG(LogPlayFabCpp, Error, TEXT("readDatetime - Unable to import FDateTime from Iso8601 String"));
+        UE_LOG(LogPlayFabCpp, Error, TEXT("readDatetime - Unable to import FDateTime from Iso8601 String. If you see a date time of all 0's, investigate the value being passed in and handle possible mis-parsing of ParseIso8601."));
+        DateTimeOut = FDateTime(0, 0, 0, 0, 0, 0, 0);
     }
 
     return DateTimeOut;

--- a/template/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabCppBaseModel.cpp.ejs
+++ b/template/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabCppBaseModel.cpp.ejs
@@ -95,8 +95,8 @@ FDateTime PlayFab::readDatetime(const TSharedPtr<FJsonValue>& value)
     FString DateString = value->AsString();
     if (!FDateTime::ParseIso8601(*DateString, DateTimeOut))
     {
-        UE_LOG(LogPlayFabCpp, Error, TEXT("readDatetime - Unable to import FDateTime from Iso8601 String. If you see a date time of all 0's, investigate the value being passed in and handle possible mis-parsing of ParseIso8601."));
-        DateTimeOut = FDateTime(0, 0, 0, 0, 0, 0, 0);
+        UE_LOG(LogPlayFabCpp, Error, TEXT("readDatetime - Unable to import FDateTime from Iso8601 String. If you see FDateTime::MinValue (FDateTime(0)), investigate the value being passed in and handle possible mis-parsing of ParseIso8601."));
+        DateTimeOut = FDateTime::MinValue;
     }
 
     return DateTimeOut;

--- a/template/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabCppBaseModel.cpp.ejs
+++ b/template/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabCppBaseModel.cpp.ejs
@@ -95,7 +95,7 @@ FDateTime PlayFab::readDatetime(const TSharedPtr<FJsonValue>& value)
     FString DateString = value->AsString();
     if (!FDateTime::ParseIso8601(*DateString, DateTimeOut))
     {
-        UE_LOG(LogPlayFabCpp, Error, TEXT("readDatetime - Unable to import FDateTime from Iso8601 String. If you see FDateTime::MinValue (FDateTime(0)), investigate the value being passed in and handle possible mis-parsing of ParseIso8601."));
+        UE_LOG(LogPlayFabCpp, Error, TEXT("readDatetime - Unable to import FDateTime from Iso8601 String. If you see FDateTime::MinValue (or FDateTime(0)), investigate the value being passed in and handle possible mis-parsing of ParseIso8601."));
         DateTimeOut = FDateTime::MinValue();
     }
 

--- a/template/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabCppBaseModel.cpp.ejs
+++ b/template/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabCppBaseModel.cpp.ejs
@@ -96,7 +96,7 @@ FDateTime PlayFab::readDatetime(const TSharedPtr<FJsonValue>& value)
     if (!FDateTime::ParseIso8601(*DateString, DateTimeOut))
     {
         UE_LOG(LogPlayFabCpp, Error, TEXT("readDatetime - Unable to import FDateTime from Iso8601 String. If you see FDateTime::MinValue (FDateTime(0)), investigate the value being passed in and handle possible mis-parsing of ParseIso8601."));
-        DateTimeOut = FDateTime::MinValue;
+        DateTimeOut = FDateTime::MinValue();
     }
 
     return DateTimeOut;


### PR DESCRIPTION
Adding default value to readDateTime if parsing fails.