### PR TITLE
Fix cook warnings seen with Unreal 4.27.1

### DIFF
--- a/template/source/PlayFab/Source/PlayFab/Classes/PlayFabBaseModel.h.ejs
+++ b/template/source/PlayFab/Source/PlayFab/Classes/PlayFabBaseModel.h.ejs
@@ -52,6 +52,6 @@ struct PLAYFAB_API FPlayFabBaseModel
 
     /** Holds the full JSON recieved from playfab. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Error | Models")
-        UPlayFabJsonObject* responseData;
+        UPlayFabJsonObject* responseData = nullptr;
 
 };

--- a/template/source/PlayFab/Source/PlayFab/Classes/PlayFabLoginResultCommon.h.ejs
+++ b/template/source/PlayFab/Source/PlayFab/Classes/PlayFabLoginResultCommon.h.ejs
@@ -16,5 +16,5 @@ struct PLAYFAB_API FPlayFabLoginResultCommon : public FPlayFabResultCommon
 
     // An authentication context returned by Login methods (can used in multi-user scenarios)
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "PlayFab | Core")
-        UPlayFabAuthenticationContext* AuthenticationContext;
+        UPlayFabAuthenticationContext* AuthenticationContext = nullptr;
 };


### PR DESCRIPTION
The following cooker warnings are generated simply by having the PlayFab plugin enabled in your project:

    LogInit: Display: LogClass: Warning: ObjectProperty FPlayFabBaseModel::responseData is not initialized properly. Module:PlayFab File:Classes/PlayFabBaseModel.h
    LogInit: Display: LogClass: Warning: ObjectProperty FPlayFabLoginResultCommon::AuthenticationContext is not initialized properly. Module:PlayFab File:Classes/PlayFabLoginResultCommon.h

Explicitly initializing these pointers to `nullptr` removes the warnings.