### PR TITLE
Update PlayFabAuthenticationContext.h.ejs

### DIFF
--- a/template/source/PlayFab/Source/PlayFabCommon/Public/PlayFabAuthenticationContext.h.ejs
+++ b/template/source/PlayFab/Source/PlayFabCommon/Public/PlayFabAuthenticationContext.h.ejs
@@ -20,21 +20,18 @@ public:
         ClientSessionTicket = PlayFabCommon::PlayFabCommonSettings::clientSessionTicket;
         EntityToken = PlayFabCommon::PlayFabCommonSettings::entityToken;
         DeveloperSecretKey = GetDefault<UPlayFabRuntimeSettings>()->DeveloperSecretKey;
-        ClientAdminSecurityCheck();
     }
 
     // Get the client session ticket that is used as an authentication token in many PlayFab API methods.
     UFUNCTION(BlueprintCallable, BlueprintPure, Category = "PlayFab | Core")
         FString& GetClientSessionTicket()
     {
-        ClientAdminSecurityCheck();
         return ClientSessionTicket;
     }
 
     // Get the client session ticket that is used as an authentication token in many PlayFab API methods.
     const FString& GetClientSessionTicket() const
     {
-        ClientAdminSecurityCheck();
         return ClientSessionTicket;
     }
 
@@ -42,7 +39,6 @@ public:
     UFUNCTION(BlueprintCallable, Category = "PlayFab | Core")
         void SetClientSessionTicket(FString InTicket)
     {
-        ClientAdminSecurityCheck();
         ClientSessionTicket = InTicket;
     }
 
@@ -70,14 +66,12 @@ public:
     UFUNCTION(BlueprintCallable, BlueprintPure, Category = "PlayFab | Core")
         FString& GetDeveloperSecretKey()
     {
-        ClientAdminSecurityCheck();
         return DeveloperSecretKey;
     }
 
     // Get the developer secret key. These keys can be used in server environments.
     const FString& GetDeveloperSecretKey() const
     {
-        ClientAdminSecurityCheck();
         return DeveloperSecretKey;
     }
 
@@ -85,7 +79,6 @@ public:
     UFUNCTION(BlueprintCallable, Category = "PlayFab | Core")
         void SetDeveloperSecretKey(FString InKey)
     {
-        ClientAdminSecurityCheck();
         DeveloperSecretKey = InKey;
     }
 
@@ -117,16 +110,6 @@ public:
         EntityToken.Empty();
         DeveloperSecretKey.Empty();
         PlayFabId.Empty();
-    }
-
-    // Check if things are in the correct order
-    UFUNCTION(BlueprintCallable, Category = "PlayFab | Core")
-    void ClientAdminSecurityCheck() const
-    {
-        checkf(
-            DeveloperSecretKey.Len() == 0 || ClientSessionTicket.Len() == 0, // The condition is true/safe if one or the other is length zero
-            TEXT("For title security, you cannot set the DeveloperSecretKey on a process which uses a Client Login")
-        );
     }
 
 private: 

--- a/template/source/PlayFab/Source/PlayFabCommon/Public/PlayFabAuthenticationContext.h.ejs
+++ b/template/source/PlayFab/Source/PlayFabCommon/Public/PlayFabAuthenticationContext.h.ejs
@@ -119,13 +119,12 @@ public:
         PlayFabId.Empty();
     }
 
-    // Check if things are in the correct order
     UFUNCTION(BlueprintCallable, Category = "PlayFab | Core")
     void ClientAdminSecurityCheck() const
     {
-        checkf(
-            DeveloperSecretKey.Len() == 0 || ClientSessionTicket.Len() == 0, // The condition is true/safe if one or the other is length zero
-            TEXT("For title security, you cannot set the DeveloperSecretKey on a process which uses a Client Login")
+        ensureMsgf(
+            DeveloperSecretKey.Len() == 0 || ClientSessionTicket.Len() == 0,
+            TEXT("For title security, you should NOT set the DeveloperSecretKey on a process which uses a Client Login.")
         );
     }
 

--- a/template/source/PlayFab/Source/PlayFabCommon/Public/PlayFabAuthenticationContext.h.ejs
+++ b/template/source/PlayFab/Source/PlayFabCommon/Public/PlayFabAuthenticationContext.h.ejs
@@ -20,18 +20,21 @@ public:
         ClientSessionTicket = PlayFabCommon::PlayFabCommonSettings::clientSessionTicket;
         EntityToken = PlayFabCommon::PlayFabCommonSettings::entityToken;
         DeveloperSecretKey = GetDefault<UPlayFabRuntimeSettings>()->DeveloperSecretKey;
+        ClientAdminSecurityCheck();
     }
 
     // Get the client session ticket that is used as an authentication token in many PlayFab API methods.
     UFUNCTION(BlueprintCallable, BlueprintPure, Category = "PlayFab | Core")
         FString& GetClientSessionTicket()
     {
+        ClientAdminSecurityCheck();
         return ClientSessionTicket;
     }
 
     // Get the client session ticket that is used as an authentication token in many PlayFab API methods.
     const FString& GetClientSessionTicket() const
     {
+        ClientAdminSecurityCheck();
         return ClientSessionTicket;
     }
 
@@ -39,6 +42,7 @@ public:
     UFUNCTION(BlueprintCallable, Category = "PlayFab | Core")
         void SetClientSessionTicket(FString InTicket)
     {
+        ClientAdminSecurityCheck();
         ClientSessionTicket = InTicket;
     }
 
@@ -66,12 +70,14 @@ public:
     UFUNCTION(BlueprintCallable, BlueprintPure, Category = "PlayFab | Core")
         FString& GetDeveloperSecretKey()
     {
+        ClientAdminSecurityCheck();
         return DeveloperSecretKey;
     }
 
     // Get the developer secret key. These keys can be used in server environments.
     const FString& GetDeveloperSecretKey() const
     {
+        ClientAdminSecurityCheck();
         return DeveloperSecretKey;
     }
 
@@ -79,6 +85,7 @@ public:
     UFUNCTION(BlueprintCallable, Category = "PlayFab | Core")
         void SetDeveloperSecretKey(FString InKey)
     {
+        ClientAdminSecurityCheck();
         DeveloperSecretKey = InKey;
     }
 
@@ -110,6 +117,16 @@ public:
         EntityToken.Empty();
         DeveloperSecretKey.Empty();
         PlayFabId.Empty();
+    }
+
+    // Check if things are in the correct order
+    UFUNCTION(BlueprintCallable, Category = "PlayFab | Core")
+    void ClientAdminSecurityCheck() const
+    {
+        checkf(
+            DeveloperSecretKey.Len() == 0 || ClientSessionTicket.Len() == 0, // The condition is true/safe if one or the other is length zero
+            TEXT("For title security, you cannot set the DeveloperSecretKey on a process which uses a Client Login")
+        );
     }
 
 private: 


### PR DESCRIPTION
removing ClientAdminSecurityCheck. Devs have been complaining they need this for local test builds. This was intended to prevent shipping a sever security issue, but it has been determined this is more of a hinderance to the development cycle, and devs should already understand admin function calls shouldn't be built into release.