### PR TITLE
update FSTicker to fix warning and prevent future compiler crashes

### DIFF
--- a/template/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
+++ b/template/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
@@ -97,7 +97,7 @@ void ACloudScriptTestResultUploader::UploadToCloudscript(const TArray<class UPla
 // A minor hack to make the Android test project auto-close, so the automated tests complete
 void CloseForAndroid() {
 #if PLATFORM_ANDROID
-#if ENGINE_MINOR_VERSION < 24	
+#if ENGINE_MINOR_VERSION < 24 && ENGINE_MAJOR_VERSION < 5
     GIsRequestingExit = true;
 #else	
     RequestEngineExit("Invalid PlayFab Test UnrealEngine Instance");

--- a/template/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.cpp.ejs
+++ b/template/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.cpp.ejs
@@ -14,7 +14,7 @@ URunTestsCommandlet::URunTestsCommandlet()
     IsEditor = false;
     IsServer = false;
     LogToConsole = true;
-#if ENGINE_MINOR_VERSION > 19
+#if ENGINE_MINOR_VERSION > 19 && ENGINE_MAJOR_VERSION < 5
     ShowProgress = true;
 #endif
     ShowErrorCount = true;
@@ -49,7 +49,7 @@ FString& URunTestsCommandlet::GetCachedSummary()
 
 int32 URunTestsCommandlet::Main(const FString& Params)
 {
-#if ENGINE_MINOR_VERSION < 24
+#if ENGINE_MINOR_VERSION < 24 && ENGINE_MAJOR_VERSION < 5
     GIsRequestingExit = false; // Global used by Unreal to indicate that the commandlet should exit.
 #endif
 
@@ -81,7 +81,11 @@ int32 URunTestsCommandlet::Main(const FString& Params)
         GFrameCounter++;
 
         const float DeltaTime = FApp::GetDeltaTime();
+#if ENGINE_MAJOR_VERSION < 5
         FTicker::GetCoreTicker().Tick(DeltaTime);
+#else
+        FTSTicker::GetCoreTicker().Tick(DeltaTime);
+#endif 
 
         Run(DeltaTime);
         if (SuiteState == PlayFabApiTestActiveState::COMPLETE)

--- a/template/source/PlayFab/Source/PlayFabCommon/Private/PlayFabCommmonUtils.cpp.ejs
+++ b/template/source/PlayFab/Source/PlayFabCommon/Private/PlayFabCommmonUtils.cpp.ejs
@@ -11,7 +11,7 @@ using namespace PlayFabCommon;
 // The newer version of GetEnvironmentVariable with a single parameter broke our 4.20 plugin build for the Epic Store
 // 
 // see {your unreal root folder}\Engine\Source\Runtime\Launch\Resources\Version.h for more preprocessor defines
-#if ENGINE_MINOR_VERSION==20
+#if ENGINE_MINOR_VERSION == 20 && ENGINE_MAJOR_VERSION < 5
 FString PlayFabCommonUtils::GetTempDir()
 {
     FString vars[] = { TEXT("TEMPDIR"), TEXT("TEMP"), TEXT("TMP") };


### PR DESCRIPTION
Older versions of Unreal will stick to the older version of the ticker. Newer versions will use the thread safe ticker.

Change also ensures other minor version checks have valid major version checks as well to prevent future 5 versions from breaking due to older 4 verion issues.