### PR TITLE
Auth GameServer EntityToken caching 

### DIFF
--- a/template/makeBp.js
+++ b/template/makeBp.js
@@ -286,16 +286,16 @@ exports.generateApiSummary = generateApiSummary;
 
 function getAuthBools(tabbing, apiCall) {
     var output = "";
-    if (apiCall.auth === "EntityToken" || apiCall.url === "/Authentication/GetEntityToken")
+    if (apiCall.auth === "EntityToken" || apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
         output += tabbing + "manager->useEntityToken = true;\n";
-    if (apiCall.auth === "SecretKey" || apiCall.url === "/Authentication/GetEntityToken")
+    if (apiCall.auth === "SecretKey" || apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
         output += tabbing + "manager->useSecretKey = true;\n";
-    if (apiCall.auth === "SessionTicket" || apiCall.url === "/Authentication/GetEntityToken")
+    if (apiCall.auth === "SessionTicket" || apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
         output += tabbing + "manager->useSessionTicket = true;\n";
 
-    if (apiCall.result === "LoginResult" || apiCall.result === "RegisterPlayFabUserResult")
+    if (apiCall.result === "LoginResult" || apiCall.result === "RegisterPlayFabUserResult" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
         output += tabbing + "manager->returnsSessionTicket = true;\n";
-    if (apiCall.url === "/Authentication/GetEntityToken")
+    if (apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
         output += tabbing + "manager->returnsEntityToken = true;\n";
 
     return output;

--- a/template/makeBp.js
+++ b/template/makeBp.js
@@ -295,7 +295,7 @@ function getAuthBools(tabbing, apiCall) {
 
     if (apiCall.result === "LoginResult" || apiCall.result === "RegisterPlayFabUserResult")
         output += tabbing + "manager->returnsSessionTicket = true;\n";
-    if (apiCall.url === "/Authentication/GetEntityToken")
+    if (apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
         output += tabbing + "manager->returnsEntityToken = true;\n";
 
     return output;

--- a/template/makeBp.js
+++ b/template/makeBp.js
@@ -286,16 +286,16 @@ exports.generateApiSummary = generateApiSummary;
 
 function getAuthBools(tabbing, apiCall) {
     var output = "";
-    if (apiCall.auth === "EntityToken" || apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
+    if (apiCall.auth === "EntityToken" || apiCall.url === "/Authentication/GetEntityToken")
         output += tabbing + "manager->useEntityToken = true;\n";
-    if (apiCall.auth === "SecretKey" || apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
+    if (apiCall.auth === "SecretKey" || apiCall.url === "/Authentication/GetEntityToken")
         output += tabbing + "manager->useSecretKey = true;\n";
-    if (apiCall.auth === "SessionTicket" || apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
+    if (apiCall.auth === "SessionTicket" || apiCall.url === "/Authentication/GetEntityToken")
         output += tabbing + "manager->useSessionTicket = true;\n";
 
-    if (apiCall.result === "LoginResult" || apiCall.result === "RegisterPlayFabUserResult" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
+    if (apiCall.result === "LoginResult" || apiCall.result === "RegisterPlayFabUserResult")
         output += tabbing + "manager->returnsSessionTicket = true;\n";
-    if (apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
+    if (apiCall.url === "/Authentication/GetEntityToken")
         output += tabbing + "manager->returnsEntityToken = true;\n";
 
     return output;

--- a/template/makeCpp.js
+++ b/template/makeCpp.js
@@ -592,7 +592,7 @@ function getContextContainer(isInstanceApi, getOrCreate) {
 }
 
 function getAuthParams(apiCall, isInstanceApi) {
-    if (apiCall.url === "/Authentication/GetEntityToken")
+    if (apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
         return "authKey, authValue";
     else if (isInstanceApi && apiCall.auth === "EntityToken")
         return "TEXT(\"X-EntityToken\"), context->GetEntityToken()";
@@ -624,7 +624,7 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
     if (apiCall.result === "LoginResult" || apiCall.request === "RegisterPlayFabUserRequest") {
         return tabbing + "if (GetDefault<UPlayFabRuntimeSettings>()->TitleId.Len() > 0)\n"
             + tabbing + "    request.TitleId = GetDefault<UPlayFabRuntimeSettings>()->TitleId;\n";
-    } else if (apiCall.url === "/Authentication/GetEntityToken") {
+    } else if (apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId") {
         return tabbing + "FString authKey; FString authValue;\n"
             + tabbing + "FString clientTicket = request.AuthenticationContext.IsValid() ? request.AuthenticationContext->GetClientSessionTicket() : PlayFabSettings::GetClientSessionTicket();\n"
             + tabbing + "FString devSecretKey = GetDefault<UPlayFabRuntimeSettings>()->DeveloperSecretKey;\n"
@@ -687,6 +687,9 @@ function getResultActions(tabbing, apiCall, isInstanceApi) {
     if (apiCall.url === "/Authentication/GetEntityToken")
         return tabbing + "if (outResult.EntityToken.Len() > 0)\n"
             + tabbing + "    " + getContextContainer(isInstanceApi, true) + "SetEntityToken(outResult.EntityToken);\n";
+    if (apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
+        return tabbing + "if (outResult.EntityToken.Len() > 0 && outResult.EntityToken->EntityToken.Len() > 0)\n"
+            + tabbing + "    " + getContextContainer(isInstanceApi, true) + "SetEntityToken(outResult.EntityToken->EntityToken);\n";
     else if (apiCall.result === "LoginResult") {
         return tabbing + "outResult.AuthenticationContext = MakeSharedUObject<UPlayFabAuthenticationContext>();\n"
             + tabbing + "if (outResult.SessionTicket.Len() > 0) {\n"

--- a/template/makeCpp.js
+++ b/template/makeCpp.js
@@ -592,7 +592,7 @@ function getContextContainer(isInstanceApi, getOrCreate) {
 }
 
 function getAuthParams(apiCall, isInstanceApi) {
-    if (apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
+    if (apiCall.url === "/Authentication/GetEntityToken")
         return "authKey, authValue";
     else if (isInstanceApi && apiCall.auth === "EntityToken")
         return "TEXT(\"X-EntityToken\"), context->GetEntityToken()";
@@ -624,7 +624,7 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
     if (apiCall.result === "LoginResult" || apiCall.request === "RegisterPlayFabUserRequest") {
         return tabbing + "if (GetDefault<UPlayFabRuntimeSettings>()->TitleId.Len() > 0)\n"
             + tabbing + "    request.TitleId = GetDefault<UPlayFabRuntimeSettings>()->TitleId;\n";
-    } else if (apiCall.url === "/Authentication/GetEntityToken" || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId") {
+    } else if (apiCall.url === "/Authentication/GetEntityToken") {
         return tabbing + "FString authKey; FString authValue;\n"
             + tabbing + "FString clientTicket = request.AuthenticationContext.IsValid() ? request.AuthenticationContext->GetClientSessionTicket() : PlayFabSettings::GetClientSessionTicket();\n"
             + tabbing + "FString devSecretKey = GetDefault<UPlayFabRuntimeSettings>()->DeveloperSecretKey;\n"


### PR DESCRIPTION
Caching the entitytoken result from AuthenticateGameServerWithCustomId into the same entitytoken stored previously.

Not creating a new seperate gameserver entitytoken as I want to confirm first this is the approach we're taking before dealing with the changes in unreal as they are a bit more work, thus, not deleting the entitytoken as we won't know for sure if it's for a gameserver or a user.