### PR TITLE
Removing Export macro on Boxed class

### DIFF
--- a/template/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h.ejs
+++ b/template/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h.ejs
@@ -16,7 +16,7 @@ namespace PlayFab
     typedef TSharedRef< TJsonReader<TCHAR> > JsonReader;
 
     template <typename BoxedType>
-    class PLAYFABCPP_API Boxed
+    class Boxed
     {
     public:
         BoxedType mValue;


### PR DESCRIPTION
The export macro on the Boxed class can cause issues in some cases. Based on these two PRs:
https://github.com/PlayFab/SDKGenerator/pull/665
https://github.com/PlayFab/UnrealMarketplacePlugin/pull/35

Confirmed this builds and tests pass.