### PR TITLE
adding Microsoft Game Development Kit (GDK) platform-specific build scripts to ExampleProjects

### DIFF
--- a/4.23/ExampleProject/BuildWinGDK.bat
+++ b/4.23/ExampleProject/BuildWinGDK.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING WinGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.23
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=WinGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.23/ExampleProject/BuildXSX.bat
+++ b/4.23/ExampleProject/BuildXSX.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XSX ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.23
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XSX
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.23/ExampleProject/BuildXboxOneGDK.bat
+++ b/4.23/ExampleProject/BuildXboxOneGDK.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XboxOneGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.23
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XboxOneGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.24/ExampleProject/BuildWinGDK.bat
+++ b/4.24/ExampleProject/BuildWinGDK.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING WinGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.24
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=WinGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.24/ExampleProject/BuildXSX.bat
+++ b/4.24/ExampleProject/BuildXSX.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XSX ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.24
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XSX
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.24/ExampleProject/BuildXboxOneGDK.bat
+++ b/4.24/ExampleProject/BuildXboxOneGDK.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XboxOneGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.24
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XboxOneGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.25/ExampleProject/BuildWinGDK.bat
+++ b/4.25/ExampleProject/BuildWinGDK.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING WinGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.25
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=WinGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.25/ExampleProject/BuildXSX.bat
+++ b/4.25/ExampleProject/BuildXSX.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XSX ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.25
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XSX
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.25/ExampleProject/BuildXboxOneGDK.bat
+++ b/4.25/ExampleProject/BuildXboxOneGDK.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XboxOneGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.25
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XboxOneGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.26/ExampleProject/BuildWinGDK.bat
+++ b/4.26/ExampleProject/BuildWinGDK.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING WinGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.26
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=WinGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.26/ExampleProject/BuildXSX.bat
+++ b/4.26/ExampleProject/BuildXSX.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XSX ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.26
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XSX
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.26/ExampleProject/BuildXboxOneGDK.bat
+++ b/4.26/ExampleProject/BuildXboxOneGDK.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XboxOneGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.26
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XboxOneGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.27/ExampleProject/BuildWinGDK.bat
+++ b/4.27/ExampleProject/BuildWinGDK.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING WinGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.27
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=WinGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.27/ExampleProject/BuildXSX.bat
+++ b/4.27/ExampleProject/BuildXSX.bat
@@ -1,0 +1,27 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+
+echo ========== BUILDING XSX ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.27
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XSX
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/4.27/ExampleProject/BuildXboxOneGDK.bat
+++ b/4.27/ExampleProject/BuildXboxOneGDK.bat
@@ -1,0 +1,26 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XboxOneGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=4.27
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XboxOneGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -nocompile -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+
+

--- a/5.0/ExampleProject/BuildWinGDK.bat
+++ b/5.0/ExampleProject/BuildWinGDK.bat
@@ -1,0 +1,32 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING WinGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=5.0
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=WinGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # UBT path. calling UBT from RunUAT gives an error about the path.
+set ubtPath=%uePath%\UE_%ueVersion%\Engine\Binaries\DotNET\UnrealBuildTool.exe
+
+rem # Build the editor exe and libraries. Needed on UE4 < 20 for the build command to work.
+call "%ubtPath%" ExampleProject Development Win64 -project="%~dp0\ExampleProject.uproject" -editorrecompile -NoHotReloadFromIDE
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -compile -compileeditor -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output
+
+

--- a/5.0/ExampleProject/BuildXSX.bat
+++ b/5.0/ExampleProject/BuildXSX.bat
@@ -1,0 +1,32 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XSX ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=5.0
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XSX
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # UBT path. calling UBT from RunUAT gives an error about the path.
+set ubtPath=%uePath%\UE_%ueVersion%\Engine\Binaries\DotNET\UnrealBuildTool.exe
+
+rem # Build the editor exe and libraries. Needed on UE4 < 20 for the build command to work.
+call "%ubtPath%" ExampleProject Development Win64 -project="%~dp0\ExampleProject.uproject" -editorrecompile -NoHotReloadFromIDE
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -compile -compileeditor -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output
+
+

--- a/5.0/ExampleProject/BuildXboxOneGDK.bat
+++ b/5.0/ExampleProject/BuildXboxOneGDK.bat
@@ -1,0 +1,32 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XboxOneGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=5.0
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XboxOneGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # UBT path. calling UBT from RunUAT gives an error about the path.
+set ubtPath=%uePath%\UE_%ueVersion%\Engine\Binaries\DotNET\UnrealBuildTool.exe
+
+rem # Build the editor exe and libraries. Needed on UE4 < 20 for the build command to work.
+call "%ubtPath%" ExampleProject Development Win64 -project="%~dp0\ExampleProject.uproject" -editorrecompile -NoHotReloadFromIDE
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -compile -compileeditor -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output
+
+

--- a/5.1/ExampleProject/BuildWinGDK.bat
+++ b/5.1/ExampleProject/BuildWinGDK.bat
@@ -1,0 +1,32 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING WinGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=5.1
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=WinGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # UBT path. calling UBT from RunUAT gives an error about the path.
+set ubtPath=%uePath%\UE_%ueVersion%\Engine\Binaries\DotNET\UnrealBuildTool.exe
+
+rem # Build the editor exe and libraries. Needed on UE4 < 20 for the build command to work.
+call "%ubtPath%" ExampleProject Development Win64 -project="%~dp0\ExampleProject.uproject" -editorrecompile -NoHotReloadFromIDE
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -compile -compileeditor -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output
+
+

--- a/5.1/ExampleProject/BuildXSX.bat
+++ b/5.1/ExampleProject/BuildXSX.bat
@@ -1,0 +1,32 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XSX ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=5.1
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XSX
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # UBT path. calling UBT from RunUAT gives an error about the path.
+set ubtPath=%uePath%\UE_%ueVersion%\Engine\Binaries\DotNET\UnrealBuildTool.exe
+
+rem # Build the editor exe and libraries. Needed on UE4 < 20 for the build command to work.
+call "%ubtPath%" ExampleProject Development Win64 -project="%~dp0\ExampleProject.uproject" -editorrecompile -NoHotReloadFromIDE
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -compile -compileeditor -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output
+
+

--- a/5.1/ExampleProject/BuildXboxOneGDK.bat
+++ b/5.1/ExampleProject/BuildXboxOneGDK.bat
@@ -1,0 +1,32 @@
+rem # Note: In order to cook for Xbox / XboxOneGDK / WinGDK, the following environment variables need to be set:
+rem #	GameDK : Points to the Microsoft GDK folder; Example: set "GameDK=C:\Program Files (x86)\\Microsoft GDK\\"
+rem #	GameDKLatest : Points to the GDK folder with the version number; Example: set "GameDKLatest=C:\Program Files (x86)\\Microsoft GDK\\210607\"
+
+echo ========== BUILDING XboxOneGDK ==========
+
+rem # Unreal Path, to change depending on your workspace setup.
+set uePath=C:\Program Files\Epic Games
+
+rem # Unreal Version, to change on every unreal version
+set ueVersion=5.1
+
+rem # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
+set uatPath=%uePath%\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat
+
+rem # Target Platform
+set targetPlatform=XboxOneGDK
+
+rem # Destination Path, where the build will end up (relative to active directory).
+set archivePath=Build\%targetPlatform%
+
+
+rem # UBT path. calling UBT from RunUAT gives an error about the path.
+set ubtPath=%uePath%\UE_%ueVersion%\Engine\Binaries\DotNET\UnrealBuildTool.exe
+
+rem # Build the editor exe and libraries. Needed on UE4 < 20 for the build command to work.
+call "%ubtPath%" ExampleProject Development Win64 -project="%~dp0\ExampleProject.uproject" -editorrecompile -NoHotReloadFromIDE
+
+rem # The actual build command. To adapt depending on the needs.
+call "%uatPath%" BuildCookRun -rocket -installed -nop4 -compile -compileeditor -project="%~dp0ExampleProject.uproject" -cook -stage -archive -archivedirectory="%~dp0%archivePath%" -package -clientconfig=Development -Platform=%targetPlatform% -compressed -CookAll -pak -prereqs -build -utf8output
+
+

--- a/template/source/BuildWinGDK.bat.ejs
+++ b/template/source/BuildWinGDK.bat.ejs
@@ -1,0 +1,4 @@
+echo ========== BUILDING WINGDK ==========
+set ueVersion=<%- ueTargetVersion %>
+call "C:\Program Files\Epic Games\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat" BuildPlugin -plugin="%~dp0\PlayFab\PlayFab.uplugin" -package="%~dp0\..\Build\Win64" -TargetPlatforms=WinGDK
+pause

--- a/template/source/BuildXSX.bat.ejs
+++ b/template/source/BuildXSX.bat.ejs
@@ -1,0 +1,4 @@
+echo ========== BUILDING XSX ==========
+set ueVersion=<%- ueTargetVersion %>
+call "C:\Program Files\Epic Games\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat" BuildPlugin -plugin="%~dp0\PlayFab\PlayFab.uplugin" -package="%~dp0\..\Build\Win64" -TargetPlatforms=XSX
+pause

--- a/template/source/BuildXboxOneGDK.bat.ejs
+++ b/template/source/BuildXboxOneGDK.bat.ejs
@@ -1,0 +1,4 @@
+echo ========== BUILDING XBOXONEGDK ==========
+set ueVersion=<%- ueTargetVersion %>
+call "C:\Program Files\Epic Games\UE_%ueVersion%\Engine\Build\BatchFiles\RunUAT.bat" BuildPlugin -plugin="%~dp0\PlayFab\PlayFab.uplugin" -package="%~dp0\..\Build\Win64" -TargetPlatforms=XboxOneGDK
+pause


### PR DESCRIPTION
Adding BuildWinGDK, BuildXSX, and BuildXboxOneGDK build scripts to ExampleProject for use by the Unreal Automation team