### PR TITLE
Wrapped raw member pointers with TObjectPtr<>. Fixed warning in PlayF…

### DIFF
--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAddonAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAddonAPI.h
@@ -499,7 +499,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -507,11 +507,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAddonModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAddonModels.h
@@ -52,10 +52,10 @@ public:
         FString AppSharedSecret;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** If an error should be returned if the addon already exists. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool ErrorIfExists = false;
@@ -99,10 +99,10 @@ public:
         FString AppSecret;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** If an error should be returned if the addon already exists. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool ErrorIfExists = false;
@@ -131,10 +131,10 @@ public:
         FString AppSecret;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** If an error should be returned if the addon already exists. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool ErrorIfExists = false;
@@ -166,10 +166,10 @@ public:
         FString AppPackageID;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** If an error should be returned if the addon already exists. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool ErrorIfExists = false;
@@ -211,10 +211,10 @@ struct PLAYFAB_API FAddonCreateOrUpdateKongregateRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** If an error should be returned if the addon already exists. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool ErrorIfExists = false;
@@ -240,13 +240,13 @@ public:
         FString ApplicationID;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** List of Nintendo Environments, currently supporting up to 4. Needs Catalog enabled. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        TArray<UPlayFabJsonObject*> Environments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Environments;
     /** If an error should be returned if the addon already exists. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool ErrorIfExists = false;
@@ -272,10 +272,10 @@ public:
         FString ClientSecret;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** If an error should be returned if the addon already exists. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool ErrorIfExists = false;
@@ -310,13 +310,13 @@ public:
         FString ApplicationId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** Enforce usage of AzurePlayFab identity in user authentication tickets. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool EnforceServiceSpecificTickets = false;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** If an error should be returned if the addon already exists. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool ErrorIfExists = false;
@@ -348,13 +348,13 @@ public:
         FString AccountKey;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** Whether ToxMod Addon is Enabled by Title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool Enabled = false;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** If an error should be returned if the addon already exists. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool ErrorIfExists = false;
@@ -380,10 +380,10 @@ public:
         FString ClientSecret;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** If an error should be returned if the addon already exists. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
         bool ErrorIfExists = false;
@@ -403,10 +403,10 @@ struct PLAYFAB_API FAddonDeleteAppleRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -423,10 +423,10 @@ struct PLAYFAB_API FAddonDeleteFacebookRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -443,10 +443,10 @@ struct PLAYFAB_API FAddonDeleteFacebookInstantGamesRequest : public FPlayFabRequ
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -463,10 +463,10 @@ struct PLAYFAB_API FAddonDeleteGoogleRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -483,10 +483,10 @@ struct PLAYFAB_API FAddonDeleteKongregateRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -503,10 +503,10 @@ struct PLAYFAB_API FAddonDeleteNintendoRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -523,10 +523,10 @@ struct PLAYFAB_API FAddonDeletePSNRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -543,10 +543,10 @@ struct PLAYFAB_API FAddonDeleteSteamRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -563,10 +563,10 @@ struct PLAYFAB_API FAddonDeleteToxModRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -583,10 +583,10 @@ struct PLAYFAB_API FAddonDeleteTwitchRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -603,10 +603,10 @@ struct PLAYFAB_API FAddonGetAppleRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -635,10 +635,10 @@ struct PLAYFAB_API FAddonGetFacebookRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -664,10 +664,10 @@ struct PLAYFAB_API FAddonGetFacebookInstantGamesRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -690,10 +690,10 @@ struct PLAYFAB_API FAddonGetGoogleRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -732,10 +732,10 @@ struct PLAYFAB_API FAddonGetKongregateRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -755,10 +755,10 @@ struct PLAYFAB_API FAddonGetNintendoRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -774,7 +774,7 @@ public:
         bool Created = false;
     /** List of Nintendo Environments, currently supporting up to 4. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        TArray<UPlayFabJsonObject*> Environments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Environments;
 };
 
 USTRUCT(BlueprintType)
@@ -784,10 +784,10 @@ struct PLAYFAB_API FAddonGetPSNRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -816,10 +816,10 @@ struct PLAYFAB_API FAddonGetSteamRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -848,10 +848,10 @@ struct PLAYFAB_API FAddonGetToxModRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -880,10 +880,10 @@ struct PLAYFAB_API FAddonGetTwitchRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Addon | Addon Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAdminAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAdminAPI.h
@@ -1896,7 +1896,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -1904,11 +1904,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAdminModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAdminModels.h
@@ -41,10 +41,10 @@ struct PLAYFAB_API FAdminBanUsersRequest : public FPlayFabRequestCommon
 public:
     /** List of ban requests to be applied. Maximum 100. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        TArray<UPlayFabJsonObject*> Bans;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Bans;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -54,7 +54,7 @@ struct PLAYFAB_API FAdminBanUsersResult : public FPlayFabResultCommon
 public:
     /** Information on the bans that were applied */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        TArray<UPlayFabJsonObject*> BanData;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BanData;
 };
 
 /**
@@ -126,7 +126,7 @@ struct PLAYFAB_API FAdminDeleteMembershipSubscriptionRequest : public FPlayFabRe
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Id of the membership to apply the override expiration date to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
         FString MembershipId;
@@ -286,7 +286,7 @@ struct PLAYFAB_API FAdminGetPlayerProfileRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
         FString PlayFabId;
@@ -296,7 +296,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
 };
 
 USTRUCT(BlueprintType)
@@ -309,7 +309,7 @@ public:
      * exist.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        UPlayFabJsonObject* PlayerProfile = nullptr;
+        TObjectPtr<UPlayFabJsonObject> PlayerProfile;
 };
 
 /**
@@ -344,7 +344,7 @@ struct PLAYFAB_API FAdminLookupUserAccountInfoResult : public FPlayFabResultComm
 public:
     /** User info for the user matching the request */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        UPlayFabJsonObject* UserInfo = nullptr;
+        TObjectPtr<UPlayFabJsonObject> UserInfo;
 };
 
 /** Get all bans for a user, including inactive and expired bans. */
@@ -365,7 +365,7 @@ struct PLAYFAB_API FAdminGetUserBansResult : public FPlayFabResultCommon
 public:
     /** Information about the bans */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        TArray<UPlayFabJsonObject*> BanData;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BanData;
 };
 
 /**
@@ -379,7 +379,7 @@ struct PLAYFAB_API FAdminResetPasswordRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The new password for the player. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
         FString Password;
@@ -416,7 +416,7 @@ struct PLAYFAB_API FAdminRevokeAllBansForUserResult : public FPlayFabResultCommo
 public:
     /** Information on the bans that were revoked. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        TArray<UPlayFabJsonObject*> BanData;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BanData;
 };
 
 /**
@@ -440,7 +440,7 @@ struct PLAYFAB_API FAdminRevokeBansResult : public FPlayFabResultCommon
 public:
     /** Information on the bans that were revoked */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        TArray<UPlayFabJsonObject*> BanData;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BanData;
 };
 
 /**
@@ -455,7 +455,7 @@ struct PLAYFAB_API FAdminSendAccountRecoveryEmailRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** User email address attached to their account */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
         FString Email;
@@ -479,7 +479,7 @@ struct PLAYFAB_API FAdminSetMembershipOverrideRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Expiration time for the membership in DateTime format, will override any subscription expirations. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
         FString ExpirationTime;
@@ -509,7 +509,7 @@ struct PLAYFAB_API FAdminUpdateBansRequest : public FPlayFabRequestCommon
 public:
     /** List of bans to be updated. Maximum 100. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        TArray<UPlayFabJsonObject*> Bans;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Bans;
 };
 
 USTRUCT(BlueprintType)
@@ -519,7 +519,7 @@ struct PLAYFAB_API FAdminUpdateBansResult : public FPlayFabResultCommon
 public:
     /** Information on the bans that were updated */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        TArray<UPlayFabJsonObject*> BanData;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BanData;
 };
 
 /**
@@ -534,7 +534,7 @@ struct PLAYFAB_API FAdminUpdateUserTitleDisplayNameRequest : public FPlayFabRequ
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** New title display name for the user - must be between 3 and 25 characters */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Account Management Models")
         FString DisplayName;
@@ -585,7 +585,7 @@ public:
         FString IssuerDiscoveryUrl;
     /** Manually specified information for an OpenID Connect issuer. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
-        UPlayFabJsonObject* IssuerInformation = nullptr;
+        TObjectPtr<UPlayFabJsonObject> IssuerInformation;
     /** Override the issuer name for user indexing and lookup. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
         FString IssuerOverride;
@@ -671,7 +671,7 @@ struct PLAYFAB_API FAdminGetPlayerSharedSecretsResult : public FPlayFabResultCom
 public:
     /** The player shared secret to use when calling Client/GetTitlePublicKey */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
-        TArray<UPlayFabJsonObject*> SharedSecrets;
+        TArray<TObjectPtr<UPlayFabJsonObject>> SharedSecrets;
 };
 
 /** Views the requested policy. Today, the only supported policy is 'ApiPolicy'. */
@@ -704,7 +704,7 @@ public:
         int32 PolicyVersion = 0;
     /** The statements in the requested policy. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
-        TArray<UPlayFabJsonObject*> Statements;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statements;
 };
 
 USTRUCT(BlueprintType)
@@ -721,7 +721,7 @@ struct PLAYFAB_API FAdminListOpenIdConnectionResponse : public FPlayFabResultCom
 public:
     /** The list of Open ID Connections */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
-        TArray<UPlayFabJsonObject*> Connections;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Connections;
 };
 
 /**
@@ -774,7 +774,7 @@ public:
         FString IssuerDiscoveryUrl;
     /** Manually specified information for an OpenID Connect issuer. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
-        UPlayFabJsonObject* IssuerInformation = nullptr;
+        TObjectPtr<UPlayFabJsonObject> IssuerInformation;
     /** Override the issuer name for user indexing and lookup. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
         FString IssuerOverride;
@@ -834,7 +834,7 @@ public:
         int32 PolicyVersion = 0;
     /** The new statements to include in the policy. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
-        TArray<UPlayFabJsonObject*> Statements;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statements;
 };
 
 USTRUCT(BlueprintType)
@@ -847,7 +847,7 @@ public:
         FString PolicyName;
     /** The statements included in the new version of the policy. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
-        TArray<UPlayFabJsonObject*> Statements;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statements;
     /**
      * Optional warnings about policy statements that may not have the intended effect. For example, resource paths that don't
      * match any known API endpoint. The policy update still succeeds when warnings are present.
@@ -880,7 +880,7 @@ public:
         int32 PolicyVersion = 0;
     /** The statements to validate. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
-        TArray<UPlayFabJsonObject*> Statements;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statements;
 };
 
 USTRUCT(BlueprintType)
@@ -890,7 +890,7 @@ struct PLAYFAB_API FAdminValidateApiPolicyResponse : public FPlayFabResultCommon
 public:
     /** Summary of what would change compared to the current policy. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
-        UPlayFabJsonObject* Diff = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Diff;
     /** Whether the proposed policy is valid and would be accepted by UpdatePolicy. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
         bool IsValid = false;
@@ -902,7 +902,7 @@ public:
         int32 PolicyVersion = 0;
     /** The full set of statements that would result from applying this update. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
-        TArray<UPlayFabJsonObject*> ResultingStatements;
+        TArray<TObjectPtr<UPlayFabJsonObject>> ResultingStatements;
     /** Validation errors that would cause UpdatePolicy to reject this request. Empty if IsValid is true. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Authentication Models")
         FString ValidationErrors;
@@ -930,7 +930,7 @@ public:
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Characters Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Characters Models")
         FString PlayFabId;
@@ -985,7 +985,7 @@ struct PLAYFAB_API FAdminGetContentListResult : public FPlayFabResultCommon
 public:
     /** List of content items. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Content Models")
-        TArray<UPlayFabJsonObject*> Contents;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Contents;
     /** Number of content items returned. We currently have a maximum of 1000 items limit. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Content Models")
         int32 ItemCount = 0;
@@ -1062,7 +1062,7 @@ public:
         EStatisticAggregationMethod AggregationMethod = StaticCast<EStatisticAggregationMethod>(0);
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** unique name of the statistic */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
         FString StatisticName;
@@ -1078,7 +1078,7 @@ struct PLAYFAB_API FAdminCreatePlayerStatisticDefinitionResult : public FPlayFab
 public:
     /** created statistic definition */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* Statistic = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Statistic;
 };
 
 /** Deletes custom properties for the specified player. The list of provided property names must be non-empty. */
@@ -1089,7 +1089,7 @@ struct PLAYFAB_API FAdminDeletePlayerCustomPropertiesRequest : public FPlayFabRe
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Optional field used for concurrency control. One can ensure that the delete operation will only be performed if the
      * player's properties have not been updated by any other clients since the last version.
@@ -1111,7 +1111,7 @@ struct PLAYFAB_API FAdminDeletePlayerCustomPropertiesResult : public FPlayFabRes
 public:
     /** The list of properties requested to be deleted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> DeletedProperties;
+        TArray<TObjectPtr<UPlayFabJsonObject>> DeletedProperties;
     /** PlayFab unique identifier of the user whose properties were deleted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
         FString PlayFabId;
@@ -1188,7 +1188,7 @@ public:
         int32 PropertiesVersion = 0;
     /** Player specific property and its corresponding value. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* Property = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Property;
 };
 
 USTRUCT(BlueprintType)
@@ -1219,7 +1219,7 @@ struct PLAYFAB_API FAdminGetPlayerStatisticDefinitionsResult : public FPlayFabRe
 public:
     /** the player statistic definitions for the title */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Statistics;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statistics;
 };
 
 USTRUCT(BlueprintType)
@@ -1229,7 +1229,7 @@ struct PLAYFAB_API FAdminGetPlayerStatisticVersionsRequest : public FPlayFabRequ
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** unique name of the statistic */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
         FString StatisticName;
@@ -1250,7 +1250,7 @@ struct PLAYFAB_API FAdminGetPlayerStatisticVersionsResult : public FPlayFabResul
 public:
     /** version change history of the statistic */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> StatisticVersions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> StatisticVersions;
 };
 
 /**
@@ -1283,7 +1283,7 @@ struct PLAYFAB_API FAdminGetUserDataResult : public FPlayFabResultCommon
 public:
     /** User specific data for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Indicates the current version of the data that has been set. This is incremented with every set call for that type of
      * data (read-only, internal, etc). This version can be provided in Get calls to find updated data.
@@ -1314,7 +1314,7 @@ struct PLAYFAB_API FAdminIncrementPlayerStatisticVersionRequest : public FPlayFa
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** unique name of the statistic */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
         FString StatisticName;
@@ -1327,7 +1327,7 @@ struct PLAYFAB_API FAdminIncrementPlayerStatisticVersionResult : public FPlayFab
 public:
     /** version change history of the statistic */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* StatisticVersion = nullptr;
+        TObjectPtr<UPlayFabJsonObject> StatisticVersion;
 };
 
 USTRUCT(BlueprintType)
@@ -1350,7 +1350,7 @@ public:
         FString PlayFabId;
     /** Player specific properties and their corresponding values for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Properties;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Properties;
     /**
      * Indicates the current version of a player's properties that have been set. This is incremented after updates and
      * deletes. This version can be provided in update and delete calls for concurrency control.
@@ -1400,7 +1400,7 @@ struct PLAYFAB_API FAdminResetUserStatisticsRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
         FString PlayFabId;
@@ -1461,7 +1461,7 @@ struct PLAYFAB_API FAdminUpdatePlayerCustomPropertiesRequest : public FPlayFabRe
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Optional field used for concurrency control. One can ensure that the update operation will only be performed if the
      * player's properties have not been updated by any other clients since last the version.
@@ -1473,7 +1473,7 @@ public:
         FString PlayFabId;
     /** Collection of properties to be set for a player. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Properties;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Properties;
 };
 
 USTRUCT(BlueprintType)
@@ -1532,7 +1532,7 @@ struct PLAYFAB_API FAdminUpdatePlayerStatisticDefinitionResult : public FPlayFab
 public:
     /** updated statistic definition */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* Statistic = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Statistic;
 };
 
 /**
@@ -1547,13 +1547,13 @@ struct PLAYFAB_API FAdminUpdateUserDataRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Key-value pairs to be written to the custom data. Note that keys are trimmed of whitespace, are limited in size, and may
      * not begin with a '!' character or be null.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Optional list of Data-keys to remove from UserData. Some SDKs cannot insert null-values into Data due to language
      * constraints. Use this to delete the keys directly.
@@ -1593,13 +1593,13 @@ struct PLAYFAB_API FAdminUpdateUserInternalDataRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Key-value pairs to be written to the custom data. Note that keys are trimmed of whitespace, are limited in size, and may
      * not begin with a '!' character or be null.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Optional list of Data-keys to remove from UserData. Some SDKs cannot insert null-values into Data due to language
      * constraints. Use this to delete the keys directly.
@@ -1629,7 +1629,7 @@ public:
         int32 Amount = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** PlayFab unique identifier of the user whose virtual currency balance is to be increased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
         FString PlayFabId;
@@ -1697,7 +1697,7 @@ struct PLAYFAB_API FAdminGetUserInventoryRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
         FString PlayFabId;
@@ -1710,16 +1710,16 @@ struct PLAYFAB_API FAdminGetUserInventoryResult : public FPlayFabResultCommon
 public:
     /** Array of inventory items belonging to the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Inventory;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Inventory;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
         FString PlayFabId;
     /** Array of virtual currency balance(s) belonging to the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrency = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrency;
     /** Array of remaining times and timestamps for virtual currencies. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrencyRechargeTimes = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrencyRechargeTimes;
 };
 
 /**
@@ -1738,10 +1738,10 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Array of items to grant and the users to whom the items are to be granted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> ItemGrants;
+        TArray<TObjectPtr<UPlayFabJsonObject>> ItemGrants;
 };
 
 /** Please note that the order of the items in the response may not match the order of items in the request. */
@@ -1752,7 +1752,7 @@ struct PLAYFAB_API FAdminGrantItemsToUsersResult : public FPlayFabResultCommon
 public:
     /** Array of items granted to users. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> ItemGrantResults;
+        TArray<TObjectPtr<UPlayFabJsonObject>> ItemGrantResults;
 };
 
 /**
@@ -1772,7 +1772,7 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The item which needs more availability. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
         FString ItemId;
@@ -1823,7 +1823,7 @@ struct PLAYFAB_API FAdminRevokeInventoryItemsRequest : public FPlayFabRequestCom
 public:
     /** Array of player items to revoke, between 1 and 25 items. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
 };
 
 USTRUCT(BlueprintType)
@@ -1833,7 +1833,7 @@ struct PLAYFAB_API FAdminRevokeInventoryItemsResult : public FPlayFabResultCommo
 public:
     /** Collection of any errors that occurred during processing. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Errors;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Errors;
 };
 
 USTRUCT(BlueprintType)
@@ -1846,7 +1846,7 @@ public:
         int32 Amount = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** PlayFab unique identifier of the user whose virtual currency balance is to be decreased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Player Item Management Models")
         FString PlayFabId;
@@ -1872,7 +1872,7 @@ struct PLAYFAB_API FAdminAddPlayerTagRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | PlayStream Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | PlayStream Models")
         FString PlayFabId;
@@ -1927,7 +1927,7 @@ struct PLAYFAB_API FAdminGetAllSegmentsResult : public FPlayFabResultCommon
 public:
     /** Array of segments for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | PlayStream Models")
-        TArray<UPlayFabJsonObject*> Segments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Segments;
 };
 
 USTRUCT(BlueprintType)
@@ -1937,7 +1937,7 @@ struct PLAYFAB_API FAdminGetPlayerSegmentsResult : public FPlayFabResultCommon
 public:
     /** Array of segments the requested player currently belongs to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | PlayStream Models")
-        TArray<UPlayFabJsonObject*> Segments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Segments;
 };
 
 USTRUCT(BlueprintType)
@@ -1947,7 +1947,7 @@ struct PLAYFAB_API FAdminGetPlayersSegmentsRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | PlayStream Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | PlayStream Models")
         FString PlayFabId;
@@ -1965,7 +1965,7 @@ struct PLAYFAB_API FAdminGetPlayerTagsRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | PlayStream Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Optional namespace to filter results by */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | PlayStream Models")
         FString Namespace;
@@ -2022,7 +2022,7 @@ struct PLAYFAB_API FAdminRemovePlayerTagRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | PlayStream Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | PlayStream Models")
         FString PlayFabId;
@@ -2051,7 +2051,7 @@ struct PLAYFAB_API FAdminAbortTaskInstanceRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** ID of a task instance that is being aborted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
         FString TaskInstanceId;
@@ -2068,7 +2068,7 @@ struct PLAYFAB_API FAdminCreateActionsOnPlayerSegmentTaskRequest : public FPlayF
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Description the task */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
         FString Description;
@@ -2080,7 +2080,7 @@ public:
         FString Name;
     /** Task details related to segment and action */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Parameter = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Parameter;
     /** Cron expression for the run schedule of the task. The expression should be in UTC. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
         FString Schedule;
@@ -2107,7 +2107,7 @@ struct PLAYFAB_API FAdminCreateCloudScriptTaskRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Description the task */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
         FString Description;
@@ -2119,7 +2119,7 @@ public:
         FString Name;
     /** Task details related to CloudScript */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Parameter = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Parameter;
     /** Cron expression for the run schedule of the task. The expression should be in UTC. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
         FString Schedule;
@@ -2136,7 +2136,7 @@ struct PLAYFAB_API FAdminCreateInsightsScheduledScalingTaskRequest : public FPla
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Description the task */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
         FString Description;
@@ -2148,7 +2148,7 @@ public:
         FString Name;
     /** Task details related to Insights Scaling */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Parameter = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Parameter;
     /** Cron expression for the run schedule of the task. The expression should be in UTC. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
         FString Schedule;
@@ -2166,7 +2166,7 @@ struct PLAYFAB_API FAdminDeleteTaskRequest : public FPlayFabRequestCommon
 public:
     /** Specify either the task ID or the name of task to be deleted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Identifier = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Identifier;
 };
 
 USTRUCT(BlueprintType)
@@ -2176,10 +2176,10 @@ struct PLAYFAB_API FAdminGetActionsOnPlayersInSegmentTaskInstanceResult : public
 public:
     /** Parameter of this task instance */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Parameter = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Parameter;
     /** Status summary of the actions-on-players-in-segment task instance */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Summary = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Summary;
 };
 
 /**
@@ -2204,10 +2204,10 @@ struct PLAYFAB_API FAdminGetCloudScriptTaskInstanceResult : public FPlayFabResul
 public:
     /** Parameter of this task instance */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Parameter = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Parameter;
     /** Status summary of the CloudScript task instance */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Summary = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Summary;
 };
 
 /**
@@ -2234,7 +2234,7 @@ public:
      * conditions set by other filters.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* TaskIdentifier = nullptr;
+        TObjectPtr<UPlayFabJsonObject> TaskIdentifier;
 };
 
 USTRUCT(BlueprintType)
@@ -2248,7 +2248,7 @@ public:
      * GetActionsOnPlayersInSegmentTaskInstance).
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        TArray<UPlayFabJsonObject*> Summaries;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Summaries;
 };
 
 USTRUCT(BlueprintType)
@@ -2258,7 +2258,7 @@ struct PLAYFAB_API FAdminGetTasksRequest : public FPlayFabRequestCommon
 public:
     /** Provide either the task ID or the task name to get a specific task. If not specified, return all defined tasks. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Identifier = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Identifier;
 };
 
 USTRUCT(BlueprintType)
@@ -2268,7 +2268,7 @@ struct PLAYFAB_API FAdminGetTasksResult : public FPlayFabResultCommon
 public:
     /** Result tasks. Empty if there is no task found. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        TArray<UPlayFabJsonObject*> Tasks;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Tasks;
 };
 
 /** The returned task instance ID can be used to query for task execution status. */
@@ -2279,10 +2279,10 @@ struct PLAYFAB_API FAdminRunTaskRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Provide either the task ID or the task name to run a task. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Identifier = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Identifier;
 };
 
 USTRUCT(BlueprintType)
@@ -2311,13 +2311,13 @@ struct PLAYFAB_API FAdminUpdateTaskRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Description the task */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
         FString Description;
     /** Specify either the task ID or the name of the task to be updated. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Identifier = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Identifier;
     /** Whether the schedule is active. Inactive schedule will not trigger task execution. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
         bool IsActive = false;
@@ -2326,7 +2326,7 @@ public:
         FString Name;
     /** Parameter object specific to the task type. See each task type's create API documentation for details. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
-        UPlayFabJsonObject* Parameter = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Parameter;
     /** Cron expression for the run schedule of the task. The expression should be in UTC. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | ScheduledTask Models")
         FString Schedule;
@@ -2348,7 +2348,7 @@ struct PLAYFAB_API FAdminCreateSegmentRequest : public FPlayFabRequestCommon
 public:
     /** Segment model with all of the segment properties data. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Segments Models")
-        UPlayFabJsonObject* SegmentModel = nullptr;
+        TObjectPtr<UPlayFabJsonObject> SegmentModel;
 };
 
 USTRUCT(BlueprintType)
@@ -2406,7 +2406,7 @@ public:
         FString ErrorMessage;
     /** List of title segments. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Segments Models")
-        TArray<UPlayFabJsonObject*> Segments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Segments;
 };
 
 /** Update segment properties data which are planning to update */
@@ -2417,7 +2417,7 @@ struct PLAYFAB_API FAdminUpdateSegmentRequest : public FPlayFabRequestCommon
 public:
     /** Segment model with all of the segment properties data. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Segments Models")
-        UPlayFabJsonObject* SegmentModel = nullptr;
+        TObjectPtr<UPlayFabJsonObject> SegmentModel;
 };
 
 USTRUCT(BlueprintType)
@@ -2461,7 +2461,7 @@ public:
         FString CreatedAt;
     /** List of Cloud Script files in this revision. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Server-Side Cloud Script Models")
-        TArray<UPlayFabJsonObject*> Files;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Files;
     /** True if this is the currently published revision */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Server-Side Cloud Script Models")
         bool IsPublished = false;
@@ -2487,7 +2487,7 @@ struct PLAYFAB_API FAdminGetCloudScriptVersionsResult : public FPlayFabResultCom
 public:
     /** List of versions */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Server-Side Cloud Script Models")
-        TArray<UPlayFabJsonObject*> Versions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Versions;
 };
 
 USTRUCT(BlueprintType)
@@ -2497,7 +2497,7 @@ struct PLAYFAB_API FAdminSetPublishedRevisionRequest : public FPlayFabRequestCom
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Revision to make the current published revision */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Server-Side Cloud Script Models")
         int32 Revision = 0;
@@ -2520,13 +2520,13 @@ struct PLAYFAB_API FAdminUpdateCloudScriptRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** PlayFab user ID of the developer initiating the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Server-Side Cloud Script Models")
         FString DeveloperPlayFabId;
     /** List of Cloud Script files to upload to create the new revision. Must have at least one file. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Server-Side Cloud Script Models")
-        TArray<UPlayFabJsonObject*> Files;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Files;
     /** Immediately publish the new revision */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Server-Side Cloud Script Models")
         bool Publish = false;
@@ -2595,7 +2595,7 @@ public:
         FString Body;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Language of the news item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
         FString Language;
@@ -2624,7 +2624,7 @@ public:
         FString Body;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Time this news was published. If not set, defaults to now. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
         FString Timestamp;
@@ -2657,7 +2657,7 @@ public:
      * to the title
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> VirtualCurrencies;
+        TArray<TObjectPtr<UPlayFabJsonObject>> VirtualCurrencies;
 };
 
 /** This non-reversible operation will permanently delete the requested store. */
@@ -2671,7 +2671,7 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** unqiue identifier for the store which is to be deleted */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
         FString StoreId;
@@ -2719,7 +2719,7 @@ struct PLAYFAB_API FAdminGetCatalogItemsResult : public FPlayFabResultCommon
 public:
     /** Array of items which can be purchased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> Catalog;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Catalog;
 };
 
 /**
@@ -2745,7 +2745,7 @@ struct PLAYFAB_API FAdminGetPublisherDataResult : public FPlayFabResultCommon
 public:
     /** a dictionary object of key / value pairs */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -2765,7 +2765,7 @@ struct PLAYFAB_API FAdminGetRandomResultTablesResult : public FPlayFabResultComm
 public:
     /** array of random result tables currently available */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        UPlayFabJsonObject* Tables = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Tables;
 };
 
 /**
@@ -2801,13 +2801,13 @@ public:
         FString CatalogVersion;
     /** Additional data about the store. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        UPlayFabJsonObject* MarketingData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MarketingData;
     /** How the store was last updated (Admin or a third party). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
         EPfSourceType Source = StaticCast<EPfSourceType>(0);
     /** Array of items which can be purchased from this store. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> Store;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Store;
     /** The ID of this store. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
         FString StoreId;
@@ -2844,7 +2844,7 @@ struct PLAYFAB_API FAdminGetTitleDataResult : public FPlayFabResultCommon
 public:
     /** a dictionary object of key / value pairs */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -2861,7 +2861,7 @@ struct PLAYFAB_API FAdminListVirtualCurrencyTypesResult : public FPlayFabResultC
 public:
     /** List of virtual currency names defined for this title */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> VirtualCurrencies;
+        TArray<TObjectPtr<UPlayFabJsonObject>> VirtualCurrencies;
 };
 
 /**
@@ -2876,7 +2876,7 @@ struct PLAYFAB_API FAdminRemoveVirtualCurrencyTypesRequest : public FPlayFabRequ
 public:
     /** List of virtual currencies to delete */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> VirtualCurrencies;
+        TArray<TObjectPtr<UPlayFabJsonObject>> VirtualCurrencies;
 };
 
 /**
@@ -2896,13 +2896,13 @@ public:
      * required and ignored in this call.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> Catalog;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Catalog;
     /** Which catalog is being updated. If null, uses the default catalog. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Should this catalog be set as the default catalog. Defaults to true. If there is currently no default catalog, this will
      * always set it.
@@ -2943,13 +2943,13 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Additional data about the store */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        UPlayFabJsonObject* MarketingData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MarketingData;
     /** Array of store items - references to catalog items, with specific pricing - to be added */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> Store;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Store;
     /** Unique identifier for the store which is to be updated */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
         FString StoreId;
@@ -3003,7 +3003,7 @@ public:
      * create/update a key.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> KeyValues;
+        TArray<TObjectPtr<UPlayFabJsonObject>> KeyValues;
     /** Name of the override. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
         FString OverrideLabel;
@@ -3073,13 +3073,13 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * array of random result tables to make available (Note: specifying an existing TableId will result in overwriting that
      * table, while any others will be added to the available set)
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Admin | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> Tables;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Tables;
 };
 
 USTRUCT(BlueprintType)

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAuthenticationAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAuthenticationAPI.h
@@ -138,7 +138,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -146,11 +146,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAuthenticationModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabAuthenticationModels.h
@@ -44,7 +44,7 @@ public:
         FString CustomId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -54,7 +54,7 @@ struct PLAYFAB_API FAuthenticationAuthenticateCustomIdResult : public FPlayFabRe
 public:
     /** The token generated used to set X-EntityToken for game_server calls. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
-        UPlayFabJsonObject* EntityToken = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EntityToken = nullptr;
     /** True if the account was newly created on this authentication. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
         bool NewlyCreated = false;
@@ -71,10 +71,10 @@ struct PLAYFAB_API FAuthenticationDeleteRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The game_server entity to be removed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -98,10 +98,10 @@ struct PLAYFAB_API FAuthenticationGetEntityTokenRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -111,7 +111,7 @@ struct PLAYFAB_API FAuthenticationGetEntityTokenResponse : public FPlayFabResult
 public:
     /** The entity id and type. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** The token used to set X-EntityToken for all entity based API calls. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
         FString EntityToken;
@@ -128,7 +128,7 @@ struct PLAYFAB_API FAuthenticationValidateEntityTokenRequest : public FPlayFabRe
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags = nullptr;
     /** Client EntityToken */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
         FString EntityToken;
@@ -141,7 +141,7 @@ struct PLAYFAB_API FAuthenticationValidateEntityTokenResponse : public FPlayFabR
 public:
     /** The entity id and type. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity = nullptr;
     /** The authenticated device for this entity, for the given login */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
         EIdentifiedDeviceType IdentifiedDeviceType = StaticCast<EIdentifiedDeviceType>(0);
@@ -153,6 +153,6 @@ public:
         FString IdentityProviderIssuedId;
     /** The lineage of this profile. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Authentication | Authentication Models")
-        UPlayFabJsonObject* Lineage = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Lineage = nullptr;
 };
 

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabBaseModel.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabBaseModel.h
@@ -55,6 +55,6 @@ struct PLAYFAB_API FPlayFabBaseModel
 
     /** Holds the full JSON recieved from playfab. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Error | Models")
-        UPlayFabJsonObject* responseData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> responseData;
 
 };

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabClientAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabClientAPI.h
@@ -2857,7 +2857,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -2865,11 +2865,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabClientModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabClientModels.h
@@ -37,7 +37,7 @@ struct PLAYFAB_API FClientAddGenericIDRequest : public FPlayFabRequestCommon
 public:
     /** Generic service identifier to add to the player account. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* GenericId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> GenericId;
 };
 
 USTRUCT(BlueprintType)
@@ -58,7 +58,7 @@ struct PLAYFAB_API FClientAddOrUpdateContactEmailRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The new contact email to associate with the player. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString EmailAddress;
@@ -78,7 +78,7 @@ struct PLAYFAB_API FClientAddUsernamePasswordRequest : public FPlayFabRequestCom
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** User email address attached to their account */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString Email;
@@ -145,7 +145,7 @@ struct PLAYFAB_API FClientGetAccountInfoResult : public FPlayFabResultCommon
 public:
     /** Account information for the local user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* AccountInfo = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AccountInfo;
 };
 
 USTRUCT(BlueprintType)
@@ -155,10 +155,10 @@ struct PLAYFAB_API FClientGetPlayerCombinedInfoRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** PlayFabId of the user whose data will be returned. If not filled included, we return the data for the calling player. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString PlayFabId;
@@ -176,7 +176,7 @@ struct PLAYFAB_API FClientGetPlayerCombinedInfoResult : public FPlayFabResultCom
 public:
     /** Results for requested info. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* InfoResultPayload = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoResultPayload;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString PlayFabId;
@@ -195,7 +195,7 @@ struct PLAYFAB_API FClientGetPlayerProfileRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString PlayFabId;
@@ -205,7 +205,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
 };
 
 USTRUCT(BlueprintType)
@@ -218,7 +218,7 @@ public:
      * exist.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* PlayerProfile = nullptr;
+        TObjectPtr<UPlayFabJsonObject> PlayerProfile;
 };
 
 USTRUCT(BlueprintType)
@@ -242,7 +242,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromBattleNetAccountIdsResult : public FP
 public:
     /** Mapping of Battle.net account identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -266,7 +266,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromFacebookIDsResult : public FPlayFabRe
 public:
     /** Mapping of Facebook identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -290,7 +290,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromFacebookInstantGamesIdsResult : publi
 public:
     /** Mapping of Facebook Instant Games identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -314,7 +314,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromGameCenterIDsResult : public FPlayFab
 public:
     /** Mapping of Game Center identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -327,7 +327,7 @@ public:
      * maximum of 10 in a single request.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> GenericIDs;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GenericIDs;
 };
 
 /** For generic service identifiers which have not been linked to PlayFab accounts, null will be returned. */
@@ -338,7 +338,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromGenericIDsResult : public FPlayFabRes
 public:
     /** Mapping of generic service identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -362,7 +362,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromGoogleIDsResult : public FPlayFabResu
 public:
     /** Mapping of Google identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -386,7 +386,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromGooglePlayGamesPlayerIDsResult : publ
 public:
     /** Mapping of Google Play Games identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -410,7 +410,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromKongregateIDsResult : public FPlayFab
 public:
     /** Mapping of Kongregate identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -434,7 +434,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromNintendoServiceAccountIdsResult : pub
 public:
     /** Mapping of Nintendo Switch Service Account identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -458,7 +458,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromNintendoSwitchDeviceIdsResult : publi
 public:
     /** Mapping of Nintendo Switch Device identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -471,7 +471,7 @@ public:
      * 10 in length.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> OpenIdSubjectIdentifiers;
+        TArray<TObjectPtr<UPlayFabJsonObject>> OpenIdSubjectIdentifiers;
 };
 
 /** For OpenId identifiers which have not been linked to PlayFab accounts, null will be returned. */
@@ -482,7 +482,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromOpenIdsResult : public FPlayFabResult
 public:
     /** Mapping of OpenId Connect identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -509,7 +509,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromPSNAccountIDsResult : public FPlayFab
 public:
     /** Mapping of PlayStation :tm: Network identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -536,7 +536,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromPSNOnlineIDsResult : public FPlayFabR
 public:
     /** Mapping of PlayStation :tm: Network identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -560,7 +560,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromSteamIDsResult : public FPlayFabResul
 public:
     /** Mapping of Steam identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -587,7 +587,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromSteamNamesResult : public FPlayFabRes
 public:
     /** Mapping of Steam identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -611,7 +611,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromTwitchIDsResult : public FPlayFabResu
 public:
     /** Mapping of Twitch identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -638,7 +638,7 @@ struct PLAYFAB_API FClientGetPlayFabIDsFromXboxLiveIDsResult : public FPlayFabRe
 public:
     /** Mapping of Xbox Live identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -654,7 +654,7 @@ public:
         FString AndroidDeviceId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the device, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -684,7 +684,7 @@ struct PLAYFAB_API FClientLinkAppleRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to a specific Apple account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -710,7 +710,7 @@ struct PLAYFAB_API FClientLinkBattleNetAccountRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to a specific Battle.net account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -729,7 +729,7 @@ public:
         FString CustomId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the custom ID, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -764,7 +764,7 @@ public:
         FString AuthenticationToken;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -784,7 +784,7 @@ struct PLAYFAB_API FClientLinkFacebookInstantGamesIdRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Facebook Instant Games signature for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString FacebookInstantGamesSignature;
@@ -807,7 +807,7 @@ struct PLAYFAB_API FClientLinkGameCenterAccountRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * If another user is already linked to the account, unlink the other user and re-link. If the current user is already
      * linked, link both accounts
@@ -852,7 +852,7 @@ struct PLAYFAB_API FClientLinkGoogleAccountRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * If another user is already linked to the account, unlink the other user and re-link. If the current user is already
      * linked, link both accounts
@@ -885,7 +885,7 @@ struct PLAYFAB_API FClientLinkGooglePlayGamesServicesAccountRequest : public FPl
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * If another user is already linked to the account, unlink the other user and re-link. If the current user is already
      * linked, link both accounts
@@ -914,7 +914,7 @@ struct PLAYFAB_API FClientLinkIOSDeviceIDRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Vendor-specific iOS identifier for the user's device. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString DeviceId;
@@ -946,7 +946,7 @@ public:
         FString AuthTicket;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -969,7 +969,7 @@ struct PLAYFAB_API FClientLinkNintendoServiceAccountRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to a specific Nintendo Switch account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -988,7 +988,7 @@ struct PLAYFAB_API FClientLinkNintendoSwitchDeviceIdRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the Nintendo Switch Device ID, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -1014,7 +1014,7 @@ public:
         FString ConnectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to a specific OpenId Connect user, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -1036,7 +1036,7 @@ public:
         FString AuthCode;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -1069,7 +1069,7 @@ struct PLAYFAB_API FClientLinkSteamAccountRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -1104,7 +1104,7 @@ public:
         FString AccessToken;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -1124,7 +1124,7 @@ struct PLAYFAB_API FClientLinkXboxAccountRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         bool ForceLink = false;
@@ -1148,7 +1148,7 @@ struct PLAYFAB_API FClientRemoveContactEmailRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1165,7 +1165,7 @@ struct PLAYFAB_API FClientRemoveGenericIDRequest : public FPlayFabRequestCommon
 public:
     /** Generic service identifier to be removed from the player. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* GenericId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> GenericId;
 };
 
 USTRUCT(BlueprintType)
@@ -1185,7 +1185,7 @@ public:
         FString Comment;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab identifier of the reported player. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString ReporteeId;
@@ -1217,7 +1217,7 @@ struct PLAYFAB_API FClientSendAccountRecoveryEmailRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** User email address attached to their account */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString Email;
@@ -1246,7 +1246,7 @@ public:
         FString AndroidDeviceId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1263,7 +1263,7 @@ struct PLAYFAB_API FClientUnlinkAppleRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1273,7 +1273,7 @@ struct PLAYFAB_API FClientUnlinkBattleNetAccountRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1289,7 +1289,7 @@ public:
         FString CustomId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1306,7 +1306,7 @@ struct PLAYFAB_API FClientUnlinkFacebookAccountRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1323,7 +1323,7 @@ struct PLAYFAB_API FClientUnlinkFacebookInstantGamesIdRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Facebook Instant Games identifier for the user. If not specified, the most recently signed in ID will be used. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString FacebookInstantGamesId;
@@ -1343,7 +1343,7 @@ struct PLAYFAB_API FClientUnlinkGameCenterAccountRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1360,7 +1360,7 @@ struct PLAYFAB_API FClientUnlinkGoogleAccountRequest : public FPlayFabRequestCom
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1377,7 +1377,7 @@ struct PLAYFAB_API FClientUnlinkGooglePlayGamesServicesAccountRequest : public F
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1394,7 +1394,7 @@ struct PLAYFAB_API FClientUnlinkIOSDeviceIDRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Vendor-specific iOS identifier for the user's device. If not specified, the most recently signed in iOS Device ID will
      * be used.
@@ -1417,7 +1417,7 @@ struct PLAYFAB_API FClientUnlinkKongregateAccountRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1434,7 +1434,7 @@ struct PLAYFAB_API FClientUnlinkNintendoServiceAccountRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1444,7 +1444,7 @@ struct PLAYFAB_API FClientUnlinkNintendoSwitchDeviceIdRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Nintendo Switch Device identifier for the user. If not specified, the most recently signed in device ID will be used. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString NintendoSwitchDeviceId;
@@ -1467,7 +1467,7 @@ public:
         FString ConnectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1477,7 +1477,7 @@ struct PLAYFAB_API FClientUnlinkPSNAccountRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1494,7 +1494,7 @@ struct PLAYFAB_API FClientUnlinkSteamAccountRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1517,7 +1517,7 @@ public:
         FString AccessToken;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1534,7 +1534,7 @@ struct PLAYFAB_API FClientUnlinkXboxAccountRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -1565,7 +1565,7 @@ struct PLAYFAB_API FClientUpdateUserTitleDisplayNameRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** New title display name for the user - must be between 3 and 25 characters. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Account Management Models")
         FString DisplayName;
@@ -1621,7 +1621,7 @@ public:
         FString AppId;
     /** Using the name or unique identifier, filter the result for get a specific placement. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Advertising Models")
-        UPlayFabJsonObject* Identifier = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Identifier;
 };
 
 /** Array of AdPlacementDetails */
@@ -1632,7 +1632,7 @@ struct PLAYFAB_API FClientGetAdPlacementsResult : public FPlayFabResultCommon
 public:
     /** Array of results */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Advertising Models")
-        TArray<UPlayFabJsonObject*> AdPlacements;
+        TArray<TObjectPtr<UPlayFabJsonObject>> AdPlacements;
 };
 
 /** Report ad activity */
@@ -1646,7 +1646,7 @@ public:
         EAdActivity Activity = StaticCast<EAdActivity>(0);
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Advertising Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique ID of the placement to report for */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Advertising Models")
         FString PlacementId;
@@ -1671,7 +1671,7 @@ struct PLAYFAB_API FClientRewardAdActivityRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Advertising Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Placement unique ID */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Advertising Models")
         FString PlacementId;
@@ -1706,7 +1706,7 @@ public:
         int32 PlacementViewsResetMinutes = 0;
     /** Reward results */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Advertising Models")
-        UPlayFabJsonObject* RewardResults = nullptr;
+        TObjectPtr<UPlayFabJsonObject> RewardResults;
 };
 
 
@@ -1722,7 +1722,7 @@ struct PLAYFAB_API FClientDeviceInfoRequest : public FPlayFabRequestCommon
 public:
     /** Information posted to the PlayStream Event. Currently arbitrary, and specific to the environment sending it. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Analytics Models")
-        UPlayFabJsonObject* Info = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Info;
 };
 
 /**
@@ -1737,13 +1737,13 @@ struct PLAYFAB_API FClientWriteClientCharacterEventRequest : public FPlayFabRequ
 public:
     /** Custom event properties. Each property consists of a name (string) and a value (JSON object). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Analytics Models")
-        UPlayFabJsonObject* Body = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Body;
     /** Unique PlayFab assigned ID for a specific character owned by a user */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Analytics Models")
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Analytics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The name of the event, within the namespace scoped to the title. The naming convention is up to the caller, but it
      * commonly follows the subject_verb_object pattern (e.g. player_logged_in).
@@ -1780,10 +1780,10 @@ struct PLAYFAB_API FClientWriteClientPlayerEventRequest : public FPlayFabRequest
 public:
     /** Custom data properties associated with the event. Each property consists of a name (string) and a value (JSON object). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Analytics Models")
-        UPlayFabJsonObject* Body = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Body;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Analytics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The name of the event, within the namespace scoped to the title. The naming convention is up to the caller, but it
      * commonly follows the subject_verb_object pattern (e.g. player_logged_in).
@@ -1807,10 +1807,10 @@ struct PLAYFAB_API FClientWriteTitleEventRequest : public FPlayFabRequestCommon
 public:
     /** Custom event properties. Each property consists of a name (string) and a value (JSON object). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Analytics Models")
-        UPlayFabJsonObject* Body = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Body;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Analytics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The name of the event, within the namespace scoped to the title. The naming convention is up to the caller, but it
      * commonly follows the subject_verb_object pattern (e.g. player_logged_in).
@@ -1886,10 +1886,10 @@ public:
      * returned.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* EntityToken = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EntityToken;
     /** Results for requested info. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoResultPayload = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoResultPayload;
     /** The time of this user's previous login. If there was no previous login, then it's DateTime.MinValue */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString LastLoginTime;
@@ -1904,10 +1904,10 @@ public:
         FString SessionTicket;
     /** Settings specific to this user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* SettingsForUser = nullptr;
+        TObjectPtr<UPlayFabJsonObject> SettingsForUser;
     /** The experimentation treatments for this user at the time of login. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* TreatmentAssignment = nullptr;
+        TObjectPtr<UPlayFabJsonObject> TreatmentAssignment;
 };
 
 /**
@@ -1938,13 +1938,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Specific Operating System version for the user's device. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString OS;
@@ -1963,7 +1963,7 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
@@ -1976,7 +1976,7 @@ public:
         FString IdentityToken;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -1992,7 +1992,7 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
@@ -2001,7 +2001,7 @@ public:
         FString IdentityToken;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -2027,13 +2027,13 @@ public:
         FString CustomId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -2051,13 +2051,13 @@ struct PLAYFAB_API FClientLoginWithEmailAddressRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Email address for the account. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString Email;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Password for the PlayFab account (6-100 characters) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString Password;
@@ -2093,13 +2093,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -2115,7 +2115,7 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
@@ -2124,7 +2124,7 @@ public:
         FString FacebookInstantGamesSignature;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -2151,13 +2151,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Unique Game Center player id. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerId;
@@ -2207,13 +2207,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -2251,13 +2251,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -2291,7 +2291,7 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Vendor-specific iOS identifier for the user's device. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString DeviceId;
@@ -2303,7 +2303,7 @@ public:
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Specific Operating System version for the user's device. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString OS;
@@ -2334,13 +2334,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Numeric user ID assigned by Kongregate */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString KongregateId;
@@ -2359,7 +2359,7 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
@@ -2368,7 +2368,7 @@ public:
         FString IdentityToken;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -2384,13 +2384,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Nintendo Switch unique identifier for the user's device. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString NintendoSwitchDeviceId;
@@ -2412,7 +2412,7 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
@@ -2424,7 +2424,7 @@ public:
         FString IdToken;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -2442,10 +2442,10 @@ struct PLAYFAB_API FClientLoginWithPlayFabRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Password for the PlayFab account (6-100 characters) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString Password;
@@ -2474,13 +2474,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Id of the PlayStation :tm: Network issuer environment. If null, defaults to production environment. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         int32 IssuerId = 0;
@@ -2512,13 +2512,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -2558,13 +2558,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -2586,13 +2586,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded body that is encrypted with the Title's public RSA key (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayerSecret;
@@ -2608,7 +2608,7 @@ struct PLAYFAB_API FClientRegisterPlayFabUserRequest : public FPlayFabRequestCom
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** An optional parameter for setting the display name for this title (3-25 characters). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString DisplayName;
@@ -2620,7 +2620,7 @@ public:
         FString EncryptedRequest;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Password for the PlayFab account (6-100 characters) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString Password;
@@ -2654,7 +2654,7 @@ public:
      * returned.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* EntityToken = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EntityToken;
     /** PlayFab unique identifier for this newly created account. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString PlayFabId;
@@ -2663,7 +2663,7 @@ public:
         FString SessionTicket;
     /** Settings specific to this user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
-        UPlayFabJsonObject* SettingsForUser = nullptr;
+        TObjectPtr<UPlayFabJsonObject> SettingsForUser;
     /** PlayFab unique user name. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Authentication Models")
         FString Username;
@@ -2738,7 +2738,7 @@ public:
         FString CharacterId;
     /** User specific data for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Character Data Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Indicates the current version of the data that has been set. This is incremented with every set call for that type of
      * data (read-only, internal, etc). This version can be provided in Get calls to find updated data.
@@ -2763,13 +2763,13 @@ public:
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Character Data Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Key-value pairs to be written to the custom data. Note that keys are trimmed of whitespace, are limited in size, and may
      * not begin with a '!' character or be null.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Character Data Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Optional list of Data-keys to remove from UserData. Some SDKs cannot insert null-values into Data due to language
      * constraints. Use this to delete the keys directly.
@@ -2817,7 +2817,7 @@ struct PLAYFAB_API FClientListUsersCharactersResult : public FPlayFabResultCommo
 public:
     /** The requested list of characters. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Characters Models")
-        TArray<UPlayFabJsonObject*> Characters;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Characters;
 };
 
 USTRUCT(BlueprintType)
@@ -2844,7 +2844,7 @@ struct PLAYFAB_API FClientGetCharacterLeaderboardResult : public FPlayFabResultC
 public:
     /** Ordered list of leaderboard entries. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Characters Models")
-        TArray<UPlayFabJsonObject*> Leaderboard;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Leaderboard;
 };
 
 USTRUCT(BlueprintType)
@@ -2865,7 +2865,7 @@ struct PLAYFAB_API FClientGetCharacterStatisticsResult : public FPlayFabResultCo
 public:
     /** The requested character statistics. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Characters Models")
-        UPlayFabJsonObject* CharacterStatistics = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CharacterStatistics;
 };
 
 USTRUCT(BlueprintType)
@@ -2895,7 +2895,7 @@ struct PLAYFAB_API FClientGetLeaderboardAroundCharacterResult : public FPlayFabR
 public:
     /** Ordered list of leaderboard entries. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Characters Models")
-        TArray<UPlayFabJsonObject*> Leaderboard;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Leaderboard;
 };
 
 USTRUCT(BlueprintType)
@@ -2920,7 +2920,7 @@ struct PLAYFAB_API FClientGetLeaderboardForUsersCharactersResult : public FPlayF
 public:
     /** Ordered list of leaderboard entries. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Characters Models")
-        TArray<UPlayFabJsonObject*> Leaderboard;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Leaderboard;
 };
 
 /**
@@ -2941,7 +2941,7 @@ public:
         FString CharacterName;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Characters Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Catalog item identifier of the item in the user's inventory that corresponds to the character in the catalog to be
      * created.
@@ -2983,10 +2983,10 @@ public:
         FString CharacterId;
     /** Statistics to be updated with the provided values, in the Key(string), Value(int) pattern. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Characters Models")
-        UPlayFabJsonObject* CharacterStatistics = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CharacterStatistics;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Characters Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -3071,7 +3071,7 @@ struct PLAYFAB_API FClientGetFriendsListRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Friend List Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Indicates which other platforms' friends should be included in the response. In HTTP, it is represented as a
      * comma-separated list of platforms.
@@ -3084,7 +3084,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Friend List Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
     /**
      * Xbox token if Xbox friends should be included. Requires Xbox be configured on PlayFab. When provided, all Xbox Live
      * users the caller is following are included regardless of whether they follow the caller back.
@@ -3109,7 +3109,7 @@ struct PLAYFAB_API FClientGetFriendsListResult : public FPlayFabResultCommon
 public:
     /** Array of friends found. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Friend List Management Models")
-        TArray<UPlayFabJsonObject*> Friends;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Friends;
 };
 
 USTRUCT(BlueprintType)
@@ -3206,10 +3206,10 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Marketplace specific payload containing details to fetch in app purchase transactions */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        UPlayFabJsonObject* MarketplaceSpecificData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MarketplaceSpecificData;
 };
 
 USTRUCT(BlueprintType)
@@ -3219,7 +3219,7 @@ struct PLAYFAB_API FClientConsumeMicrosoftStoreEntitlementsResponse : public FPl
 public:
     /** Details for the items purchased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
 };
 
 USTRUCT(BlueprintType)
@@ -3232,10 +3232,10 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Marketplace specific payload containing details to fetch in app purchase transactions */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        UPlayFabJsonObject* MarketplaceSpecificData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MarketplaceSpecificData;
 };
 
 USTRUCT(BlueprintType)
@@ -3245,7 +3245,7 @@ struct PLAYFAB_API FClientConsumePS5EntitlementsResult : public FPlayFabResultCo
 public:
     /** Details for the items purchased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
 };
 
 USTRUCT(BlueprintType)
@@ -3258,7 +3258,7 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Id of the PlayStation :tm: Network service label to consume entitlements from */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
         int32 ServiceLabel = 0;
@@ -3271,7 +3271,7 @@ struct PLAYFAB_API FClientConsumePSNEntitlementsResult : public FPlayFabResultCo
 public:
     /** Array of items granted to the player as a result of consuming entitlements. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        TArray<UPlayFabJsonObject*> ItemsGranted;
+        TArray<TObjectPtr<UPlayFabJsonObject>> ItemsGranted;
 };
 
 USTRUCT(BlueprintType)
@@ -3284,7 +3284,7 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Token provided by the Xbox Live SDK/XDK method GetTokenAndSignatureAsync("POST", "https://playfabapi.com/", ""). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
         FString XboxToken;
@@ -3297,7 +3297,7 @@ struct PLAYFAB_API FClientConsumeXboxEntitlementsResult : public FPlayFabResultC
 public:
     /** Details for the items purchased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
 };
 
 USTRUCT(BlueprintType)
@@ -3359,7 +3359,7 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded receipt data, passed back by the App Store as a result of a successful purchase. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
         FString ReceiptData;
@@ -3376,7 +3376,7 @@ struct PLAYFAB_API FClientRestoreIOSPurchasesResult : public FPlayFabResultCommo
 public:
     /** Fulfilled inventory items and recorded purchases in fulfillment of the validated receipt transactions. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        TArray<UPlayFabJsonObject*> Fulfillments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Fulfillments;
 };
 
 USTRUCT(BlueprintType)
@@ -3392,7 +3392,7 @@ public:
         FString CurrencyCode;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Amount of the stated currency paid, in centesimal units. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
         int32 PurchasePrice = 0;
@@ -3416,7 +3416,7 @@ struct PLAYFAB_API FClientValidateAmazonReceiptResult : public FPlayFabResultCom
 public:
     /** Fulfilled inventory items and recorded purchases in fulfillment of the validated receipt transactions. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        TArray<UPlayFabJsonObject*> Fulfillments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Fulfillments;
 };
 
 /**
@@ -3439,7 +3439,7 @@ public:
         FString CurrencyCode;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Amount of the stated currency paid, in centesimal units. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
         int32 PurchasePrice = 0;
@@ -3463,7 +3463,7 @@ struct PLAYFAB_API FClientValidateGooglePlayPurchaseResult : public FPlayFabResu
 public:
     /** Fulfilled inventory items and recorded purchases in fulfillment of the validated receipt transactions. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        TArray<UPlayFabJsonObject*> Fulfillments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Fulfillments;
 };
 
 /**
@@ -3486,7 +3486,7 @@ public:
         FString CurrencyCode;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Base64 encoded receipt data, passed back by the App Store as a result of a successful purchase. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
         FString JwsReceiptData;
@@ -3510,7 +3510,7 @@ struct PLAYFAB_API FClientValidateIOSReceiptResult : public FPlayFabResultCommon
 public:
     /** Fulfilled inventory items and recorded purchases in fulfillment of the validated receipt transactions. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        TArray<UPlayFabJsonObject*> Fulfillments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Fulfillments;
 };
 
 USTRUCT(BlueprintType)
@@ -3526,7 +3526,7 @@ public:
         FString CurrencyCode;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Amount of the stated currency paid, in centesimal units. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
         int32 PurchasePrice = 0;
@@ -3547,7 +3547,7 @@ struct PLAYFAB_API FClientValidateWindowsReceiptResult : public FPlayFabResultCo
 public:
     /** Fulfilled inventory items and recorded purchases in fulfillment of the validated receipt transactions. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Platform Specific Methods Models")
-        TArray<UPlayFabJsonObject*> Fulfillments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Fulfillments;
 };
 
 
@@ -3563,7 +3563,7 @@ struct PLAYFAB_API FClientDeletePlayerCustomPropertiesRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Optional field used for concurrency control. One can ensure that the delete operation will only be performed if the
      * player's properties have not been updated by any other clients since the last version.
@@ -3582,7 +3582,7 @@ struct PLAYFAB_API FClientDeletePlayerCustomPropertiesResult : public FPlayFabRe
 public:
     /** The list of properties requested to be deleted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> DeletedProperties;
+        TArray<TObjectPtr<UPlayFabJsonObject>> DeletedProperties;
     /**
      * Indicates the current version of a player's properties that have been set. This is incremented after updates and
      * deletes. This version can be provided in update and delete calls for concurrency control.
@@ -3598,7 +3598,7 @@ struct PLAYFAB_API FClientGetFriendLeaderboardRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Indicates which other platforms' friends should be included in the response. In HTTP, it is represented as a
      * comma-separated list of platforms.
@@ -3614,7 +3614,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
     /** Position in the leaderboard to start this listing (defaults to the first entry). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
         int32 StartPosition = 0;
@@ -3640,7 +3640,7 @@ struct PLAYFAB_API FClientGetLeaderboardResult : public FPlayFabResultCommon
 public:
     /** Ordered listing of users and their positions in the requested leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Leaderboard;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Leaderboard;
     /** The time the next scheduled reset will occur. Null if the leaderboard does not reset on a schedule. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
         FString NextReset;
@@ -3656,7 +3656,7 @@ struct PLAYFAB_API FClientGetFriendLeaderboardAroundPlayerRequest : public FPlay
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Indicates which other platforms' friends should be included in the response. In HTTP, it is represented as a
      * comma-separated list of platforms.
@@ -3675,7 +3675,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
     /** Statistic used to rank players for this leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
         FString StatisticName;
@@ -3703,7 +3703,7 @@ struct PLAYFAB_API FClientGetFriendLeaderboardAroundPlayerResult : public FPlayF
 public:
     /** Ordered listing of users and their positions in the requested leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Leaderboard;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Leaderboard;
     /** The time the next scheduled reset will occur. Null if the leaderboard does not reset on a schedule. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
         FString NextReset;
@@ -3719,7 +3719,7 @@ struct PLAYFAB_API FClientGetLeaderboardRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Maximum number of entries to retrieve. Default 10, maximum 100. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
         int32 MaxResultsCount = 0;
@@ -3729,7 +3729,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
     /** Position in the leaderboard to start this listing (defaults to the first entry). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
         int32 StartPosition = 0;
@@ -3751,7 +3751,7 @@ struct PLAYFAB_API FClientGetLeaderboardAroundPlayerRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Maximum number of entries to retrieve. Default 10, maximum 100. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
         int32 MaxResultsCount = 0;
@@ -3764,7 +3764,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
     /** Statistic used to rank players for this leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
         FString StatisticName;
@@ -3787,7 +3787,7 @@ struct PLAYFAB_API FClientGetLeaderboardAroundPlayerResult : public FPlayFabResu
 public:
     /** Ordered listing of users and their positions in the requested leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Leaderboard;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Leaderboard;
     /** The time the next scheduled reset will occur. Null if the leaderboard does not reset on a schedule. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
         FString NextReset;
@@ -3819,7 +3819,7 @@ public:
         int32 PropertiesVersion = 0;
     /** Player specific property and its corresponding value. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* Property = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Property;
 };
 
 USTRUCT(BlueprintType)
@@ -3829,7 +3829,7 @@ struct PLAYFAB_API FClientGetPlayerStatisticsRequest : public FPlayFabRequestCom
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** statistics to return (current version will be returned for each) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
         FString StatisticNames;
@@ -3838,7 +3838,7 @@ public:
      * returned)
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> StatisticNameVersions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> StatisticNameVersions;
 };
 
 /** In addition to being available for use by the title, the statistics are used for all leaderboard operations in PlayFab. */
@@ -3849,7 +3849,7 @@ struct PLAYFAB_API FClientGetPlayerStatisticsResult : public FPlayFabResultCommo
 public:
     /** User statistics for the requested user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Statistics;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statistics;
 };
 
 USTRUCT(BlueprintType)
@@ -3859,7 +3859,7 @@ struct PLAYFAB_API FClientGetPlayerStatisticVersionsRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** unique name of the statistic */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
         FString StatisticName;
@@ -3872,7 +3872,7 @@ struct PLAYFAB_API FClientGetPlayerStatisticVersionsResult : public FPlayFabResu
 public:
     /** version change history of the statistic */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> StatisticVersions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> StatisticVersions;
 };
 
 /**
@@ -3910,7 +3910,7 @@ struct PLAYFAB_API FClientGetUserDataResult : public FPlayFabResultCommon
 public:
     /** User specific data for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Indicates the current version of the data that has been set. This is incremented with every set call for that type of
      * data (read-only, internal, etc). This version can be provided in Get calls to find updated data.
@@ -3933,7 +3933,7 @@ struct PLAYFAB_API FClientListPlayerCustomPropertiesResult : public FPlayFabResu
 public:
     /** Player specific properties and their corresponding values for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Properties;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Properties;
     /**
      * Indicates the current version of a player's properties that have been set. This is incremented after updates and
      * deletes. This version can be provided in update and delete calls for concurrency control.
@@ -3954,7 +3954,7 @@ struct PLAYFAB_API FClientUpdatePlayerCustomPropertiesRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Optional field used for concurrency control. One can ensure that the update operation will only be performed if the
      * player's properties have not been updated by any other clients since last the version.
@@ -3963,7 +3963,7 @@ public:
         int32 ExpectedPropertiesVersion = 0;
     /** Collection of properties to be set for a player. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Properties;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Properties;
 };
 
 USTRUCT(BlueprintType)
@@ -3995,10 +3995,10 @@ struct PLAYFAB_API FClientUpdatePlayerStatisticsRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Statistics to be updated with the provided values */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Statistics;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statistics;
 };
 
 USTRUCT(BlueprintType)
@@ -4021,13 +4021,13 @@ struct PLAYFAB_API FClientUpdateUserDataRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Key-value pairs to be written to the custom data. Note that keys are trimmed of whitespace, are limited in size, and may
      * not begin with a '!' character or be null.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Optional list of Data-keys to remove from UserData. Some SDKs cannot insert null-values into Data due to language
      * constraints. Use this to delete the keys directly.
@@ -4071,7 +4071,7 @@ public:
         int32 Amount = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Name of the virtual currency which is to be incremented. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
         FString VirtualCurrency;
@@ -4114,7 +4114,7 @@ struct PLAYFAB_API FClientConfirmPurchaseRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Purchase order identifier returned from StartPurchase. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
         FString OrderId;
@@ -4132,7 +4132,7 @@ struct PLAYFAB_API FClientConfirmPurchaseResult : public FPlayFabResultCommon
 public:
     /** Array of items purchased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
     /** Purchase order identifier. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
         FString OrderId;
@@ -4154,7 +4154,7 @@ public:
         int32 ConsumeCount = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique instance identifier of the item to be consumed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
         FString ItemInstanceId;
@@ -4191,7 +4191,7 @@ public:
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -4204,13 +4204,13 @@ public:
         FString CharacterId;
     /** Array of inventory items belonging to the character. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Inventory;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Inventory;
     /** Array of virtual currency balance(s) belonging to the character. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrency = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrency;
     /** Array of remaining times and timestamps for virtual currencies. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrencyRechargeTimes = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrencyRechargeTimes;
 };
 
 USTRUCT(BlueprintType)
@@ -4275,7 +4275,7 @@ struct PLAYFAB_API FClientGetUserInventoryRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 /**
@@ -4290,13 +4290,13 @@ struct PLAYFAB_API FClientGetUserInventoryResult : public FPlayFabResultCommon
 public:
     /** Array of inventory items belonging to the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Inventory;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Inventory;
     /** Array of virtual currency balance(s) belonging to the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrency = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrency;
     /** Array of remaining times and timestamps for virtual currencies. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrencyRechargeTimes = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrencyRechargeTimes;
 };
 
 /**
@@ -4315,7 +4315,7 @@ public:
         FString Currency;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Purchase order identifier returned from StartPurchase. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
         FString OrderId;
@@ -4362,10 +4362,10 @@ public:
         ETransactionStatus Status = StaticCast<ETransactionStatus>(0);
     /** Virtual currencies granted by the transaction, if any. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* VCAmount = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VCAmount;
     /** Current virtual currency balances for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrency = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrency;
 };
 
 /**
@@ -4385,7 +4385,7 @@ public:
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique identifier of the item to purchase. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
         FString ItemId;
@@ -4407,7 +4407,7 @@ struct PLAYFAB_API FClientPurchaseItemResult : public FPlayFabResultCommon
 public:
     /** Details for the items purchased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
 };
 
 /**
@@ -4431,7 +4431,7 @@ public:
         FString CouponCode;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -4441,7 +4441,7 @@ struct PLAYFAB_API FClientRedeemCouponResult : public FPlayFabResultCommon
 public:
     /** Items granted to the player as a result of redeeming the coupon. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> GrantedItems;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GrantedItems;
 };
 
 /**
@@ -4459,10 +4459,10 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Array of items to purchase. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
     /** Store through which to purchase items. If not set, prices will be pulled from the catalog itself. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
         FString StoreId;
@@ -4475,16 +4475,16 @@ struct PLAYFAB_API FClientStartPurchaseResult : public FPlayFabResultCommon
 public:
     /** Cart items to be purchased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Contents;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Contents;
     /** Purchase order identifier. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
         FString OrderId;
     /** Available methods by which the user can pay. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> PaymentOptions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> PaymentOptions;
     /** Current virtual currency totals for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrencyBalances = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrencyBalances;
 };
 
 /** This API must be enabled for use as an option in the game manager website. It is disabled by default. */
@@ -4498,7 +4498,7 @@ public:
         int32 Amount = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Name of the virtual currency which is to be decremented. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
         FString VirtualCurrency;
@@ -4524,7 +4524,7 @@ public:
         FString ContainerItemInstanceId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * ItemInstanceId of the key that will be consumed by unlocking this container. If the container requires a key, this
      * parameter is required.
@@ -4541,7 +4541,7 @@ struct PLAYFAB_API FClientUnlockContainerItemResult : public FPlayFabResultCommo
 public:
     /** Items granted to the player as a result of unlocking the container. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> GrantedItems;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GrantedItems;
     /** Unique instance identifier of the container unlocked. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
         FString UnlockedItemInstanceId;
@@ -4550,7 +4550,7 @@ public:
         FString UnlockedWithItemInstanceId;
     /** Virtual currency granted to the player as a result of unlocking the container. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrency = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrency;
 };
 
 /** Specify the type of container to open and optionally the catalogVersion for the container to open */
@@ -4573,7 +4573,7 @@ public:
         FString ContainerItemId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 
@@ -4595,7 +4595,7 @@ struct PLAYFAB_API FClientGetPlayerSegmentsResult : public FPlayFabResultCommon
 public:
     /** Array of segments the requested player currently belongs to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | PlayStream Models")
-        TArray<UPlayFabJsonObject*> Segments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Segments;
 };
 
 /**
@@ -4610,7 +4610,7 @@ struct PLAYFAB_API FClientGetPlayerTagsRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | PlayStream Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Optional namespace to filter results by */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | PlayStream Models")
         FString Namespace;
@@ -4644,13 +4644,13 @@ struct PLAYFAB_API FClientExecuteCloudScriptRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the CloudScript function to execute */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Server-Side Cloud Script Models")
         FString FunctionName;
     /** Object that is passed in to the function as the first argument */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionParameter = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionParameter;
     /**
      * Generate a 'player_executed_cloudscript' PlayStream event containing the results of the function execution and other
      * contextual information. This event will show up in the PlayStream debugger console for the player in Game Manager.
@@ -4679,7 +4679,7 @@ public:
         int32 APIRequestsIssued = 0;
     /** Information about the error, if any, that occurred during execution */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* Error = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Error;
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Server-Side Cloud Script Models")
         int32 ExecutionTimeSeconds = 0;
     /** The name of the function that executed */
@@ -4687,7 +4687,7 @@ public:
         FString FunctionName;
     /** The object returned from the CloudScript function, if any */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionResult = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionResult;
     /**
      * Flag indicating if the FunctionResult was too large and was subsequently dropped from this event. This only occurs if
      * the total event size is larger than 350KB.
@@ -4702,7 +4702,7 @@ public:
      * and log.error() and error entries for API and HTTP request failures.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Server-Side Cloud Script Models")
-        TArray<UPlayFabJsonObject*> Logs;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Logs;
     /**
      * Flag indicating if the logs were too large and were subsequently dropped from this event. This only occurs if the total
      * event size is larger than 350KB after the FunctionResult was removed.
@@ -4797,7 +4797,7 @@ struct PLAYFAB_API FClientGetSharedGroupDataResult : public FPlayFabResultCommon
 public:
     /** Data for the requested keys. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Shared Group Data Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /** List of PlayFabId identifiers for the members of this group, if requested. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Shared Group Data Models")
         FString Members;
@@ -4836,13 +4836,13 @@ struct PLAYFAB_API FClientUpdateSharedGroupDataRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Shared Group Data Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Key-value pairs to be written to the custom data. Note that keys are trimmed of whitespace, are limited in size, and may
      * not begin with a '!' character or be null.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Shared Group Data Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Optional list of Data-keys to remove from UserData. Some SDKs cannot insert null-values into Data due to language
      * constraints. Use this to delete the keys directly.
@@ -4890,7 +4890,7 @@ struct PLAYFAB_API FClientGetCatalogItemsResult : public FPlayFabResultCommon
 public:
     /** Array of items which can be purchased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> Catalog;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Catalog;
 };
 
 /**
@@ -4916,7 +4916,7 @@ struct PLAYFAB_API FClientGetPublisherDataResult : public FPlayFabResultCommon
 public:
     /** a dictionary object of key / value pairs */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Title-Wide Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
 };
 
 /**
@@ -4953,13 +4953,13 @@ public:
         FString CatalogVersion;
     /** Additional data about the store. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Title-Wide Data Management Models")
-        UPlayFabJsonObject* MarketingData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MarketingData;
     /** How the store was last updated (Admin or a third party). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Title-Wide Data Management Models")
         EPfSourceType Source = StaticCast<EPfSourceType>(0);
     /** Array of items which can be purchased from this store. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> Store;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Store;
     /** The ID of this store. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Title-Wide Data Management Models")
         FString StoreId;
@@ -5018,7 +5018,7 @@ struct PLAYFAB_API FClientGetTitleDataResult : public FPlayFabResultCommon
 public:
     /** a dictionary object of key / value pairs */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Title-Wide Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -5038,7 +5038,7 @@ struct PLAYFAB_API FClientGetTitleNewsResult : public FPlayFabResultCommon
 public:
     /** Array of news items. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> News;
+        TArray<TObjectPtr<UPlayFabJsonObject>> News;
 };
 
 
@@ -5072,7 +5072,7 @@ struct PLAYFAB_API FClientAcceptTradeResponse : public FPlayFabResultCommon
 public:
     /** Details about trade which was just accepted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Trading Models")
-        UPlayFabJsonObject* Trade = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Trade;
 };
 
 USTRUCT(BlueprintType)
@@ -5092,7 +5092,7 @@ struct PLAYFAB_API FClientCancelTradeResponse : public FPlayFabResultCommon
 public:
     /** Details about trade which was just canceled. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Trading Models")
-        UPlayFabJsonObject* Trade = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Trade;
 };
 
 USTRUCT(BlueprintType)
@@ -5112,10 +5112,10 @@ struct PLAYFAB_API FClientGetPlayerTradesResponse : public FPlayFabResultCommon
 public:
     /** History of trades which this player has accepted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Trading Models")
-        TArray<UPlayFabJsonObject*> AcceptedTrades;
+        TArray<TObjectPtr<UPlayFabJsonObject>> AcceptedTrades;
     /** The trades for this player which are currently available to be accepted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Trading Models")
-        TArray<UPlayFabJsonObject*> OpenedTrades;
+        TArray<TObjectPtr<UPlayFabJsonObject>> OpenedTrades;
 };
 
 USTRUCT(BlueprintType)
@@ -5138,7 +5138,7 @@ struct PLAYFAB_API FClientGetTradeStatusResponse : public FPlayFabResultCommon
 public:
     /** Information about the requested trade. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Trading Models")
-        UPlayFabJsonObject* Trade = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Trade;
 };
 
 USTRUCT(BlueprintType)
@@ -5167,6 +5167,6 @@ struct PLAYFAB_API FClientOpenTradeResponse : public FPlayFabResultCommon
 public:
     /** The information about the trade that was just opened. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Trading Models")
-        UPlayFabJsonObject* Trade = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Trade;
 };
 

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabCloudScriptAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabCloudScriptAPI.h
@@ -296,7 +296,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -304,11 +304,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabCloudScriptModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabCloudScriptModels.h
@@ -40,7 +40,7 @@ public:
         int32 APIRequestsIssued = 0;
     /** Information about the error, if any, that occurred during execution */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* Error = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Error;
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
         int32 ExecutionTimeSeconds = 0;
     /** The name of the function that executed */
@@ -48,7 +48,7 @@ public:
         FString FunctionName;
     /** The object returned from the CloudScript function, if any */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionResult = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionResult;
     /**
      * Flag indicating if the FunctionResult was too large and was subsequently dropped from this event. This only occurs if
      * the total event size is larger than 350KB.
@@ -63,7 +63,7 @@ public:
      * and log.error() and error entries for API and HTTP request failures.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        TArray<UPlayFabJsonObject*> Logs;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Logs;
     /**
      * Flag indicating if the logs were too large and were subsequently dropped from this event. This only occurs if the total
      * event size is larger than 350KB after the FunctionResult was removed.
@@ -91,16 +91,16 @@ struct PLAYFAB_API FCloudScriptExecuteEntityCloudScriptRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The name of the CloudScript function to execute */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
         FString FunctionName;
     /** Object that is passed in to the function as the first argument */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionParameter = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionParameter;
     /**
      * Generate a 'entity_executed_cloudscript' PlayStream event containing the results of the function execution and other
      * contextual information. This event will show up in the PlayStream debugger console for the player in Game Manager.
@@ -127,16 +127,16 @@ struct PLAYFAB_API FCloudScriptExecuteFunctionRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The name of the CloudScript function to execute */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
         FString FunctionName;
     /** Object that is passed in to the function as the FunctionArgument field of the FunctionExecutionContext data structure */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionParameter = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionParameter;
     /**
      * Generate a 'entity_executed_cloudscript_function' PlayStream event containing the results of the function execution and
      * other contextual information. This event will show up in the PlayStream debugger console for the player in Game Manager.
@@ -152,7 +152,7 @@ struct PLAYFAB_API FCloudScriptExecuteFunctionResult : public FPlayFabResultComm
 public:
     /** Error from the CloudScript Azure Function. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* Error = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Error;
     /** The amount of time the function took to execute */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
         int32 ExecutionTimeMilliseconds = 0;
@@ -161,7 +161,7 @@ public:
         FString FunctionName;
     /** The object returned from the function, if any */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionResult = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionResult;
     /** The size in bytes of the object returned from the function, if any */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
         int32 FunctionResultSize = 0;
@@ -177,7 +177,7 @@ struct PLAYFAB_API FCloudScriptGetFunctionRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the function to register */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
         FString FunctionName;
@@ -209,7 +209,7 @@ struct PLAYFAB_API FCloudScriptListEventHubFunctionsResult : public FPlayFabResu
 public:
     /** The list of EventHub triggered functions that are currently registered for the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        TArray<UPlayFabJsonObject*> Functions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Functions;
 };
 
 /**
@@ -223,7 +223,7 @@ struct PLAYFAB_API FCloudScriptListFunctionsRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -233,7 +233,7 @@ struct PLAYFAB_API FCloudScriptListFunctionsResult : public FPlayFabResultCommon
 public:
     /** The list of functions that are currently registered for the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        TArray<UPlayFabJsonObject*> Functions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Functions;
 };
 
 USTRUCT(BlueprintType)
@@ -243,7 +243,7 @@ struct PLAYFAB_API FCloudScriptListHttpFunctionsResult : public FPlayFabResultCo
 public:
     /** The list of HTTP triggered functions that are currently registered for the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        TArray<UPlayFabJsonObject*> Functions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Functions;
 };
 
 USTRUCT(BlueprintType)
@@ -253,7 +253,7 @@ struct PLAYFAB_API FCloudScriptListQueuedFunctionsResult : public FPlayFabResult
 public:
     /** The list of Queue triggered functions that are currently registered for the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        TArray<UPlayFabJsonObject*> Functions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Functions;
 };
 
 USTRUCT(BlueprintType)
@@ -270,13 +270,13 @@ struct PLAYFAB_API FCloudScriptPostFunctionResultForEntityTriggeredActionRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The result of the function execution. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionResult = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionResult;
 };
 
 USTRUCT(BlueprintType)
@@ -286,13 +286,13 @@ struct PLAYFAB_API FCloudScriptPostFunctionResultForFunctionExecutionRequest : p
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The result of the function execution. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionResult = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionResult;
 };
 
 USTRUCT(BlueprintType)
@@ -302,16 +302,16 @@ struct PLAYFAB_API FCloudScriptPostFunctionResultForPlayerTriggeredActionRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The result of the function execution. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionResult = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionResult;
     /** The player profile the function was invoked with. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* PlayerProfile = nullptr;
+        TObjectPtr<UPlayFabJsonObject> PlayerProfile;
     /** The triggering PlayStream event, if any, that caused the function to be invoked. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* PlayStreamEventEnvelope = nullptr;
+        TObjectPtr<UPlayFabJsonObject> PlayStreamEventEnvelope;
 };
 
 USTRUCT(BlueprintType)
@@ -321,13 +321,13 @@ struct PLAYFAB_API FCloudScriptPostFunctionResultForScheduledTaskRequest : publi
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The result of the function execution */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionResult = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionResult;
     /** The id of the scheduled task that invoked the function. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* ScheduledTaskId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ScheduledTaskId;
 };
 
 /**
@@ -344,7 +344,7 @@ public:
         FString ConnectionString;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the event hub for the Azure Function. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
         FString EventHubName;
@@ -360,7 +360,7 @@ struct PLAYFAB_API FCloudScriptRegisterHttpFunctionRequest : public FPlayFabRequ
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the function to register */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
         FString FunctionName;
@@ -383,7 +383,7 @@ public:
         FString ConnectionString;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the function to register */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
         FString FunctionName;
@@ -399,7 +399,7 @@ struct PLAYFAB_API FCloudScriptUnregisterFunctionRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the function to register */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | CloudScript | Server-Side Cloud Script Models")
         FString FunctionName;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabDataAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabDataAPI.h
@@ -181,7 +181,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -189,11 +189,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabDataModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabDataModels.h
@@ -38,10 +38,10 @@ struct PLAYFAB_API FDataAbortFileUploadsRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Names of the files to have their pending uploads aborted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
         FString FileNames;
@@ -60,7 +60,7 @@ struct PLAYFAB_API FDataAbortFileUploadsResponse : public FPlayFabResultCommon
 public:
     /** The entity id and type. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The current version of the profile, can be used for concurrency control during updates. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
         int32 ProfileVersion = 0;
@@ -74,10 +74,10 @@ struct PLAYFAB_API FDataDeleteFilesRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Names of the files to be deleted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
         FString FileNames;
@@ -96,7 +96,7 @@ struct PLAYFAB_API FDataDeleteFilesResponse : public FPlayFabResultCommon
 public:
     /** The entity id and type. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The current version of the profile, can be used for concurrency control during updates. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
         int32 ProfileVersion = 0;
@@ -113,10 +113,10 @@ struct PLAYFAB_API FDataFinalizeFileUploadsRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Names of the files to be finalized. Restricted to a-Z, 0-9, '(', ')', '_', '-' and '.' */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
         FString FileNames;
@@ -132,10 +132,10 @@ struct PLAYFAB_API FDataFinalizeFileUploadsResponse : public FPlayFabResultCommo
 public:
     /** The entity id and type. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Collection of metadata for the entity's files */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Metadata = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Metadata;
     /** The current version of the profile, can be used for concurrency control during updates. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
         int32 ProfileVersion = 0;
@@ -153,10 +153,10 @@ struct PLAYFAB_API FDataGetFilesRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
 };
 
 USTRUCT(BlueprintType)
@@ -166,10 +166,10 @@ struct PLAYFAB_API FDataGetFilesResponse : public FPlayFabResultCommon
 public:
     /** The entity id and type. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Collection of metadata for the entity's files */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Metadata = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Metadata;
     /** The current version of the profile, can be used for concurrency control during updates. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
         int32 ProfileVersion = 0;
@@ -186,10 +186,10 @@ struct PLAYFAB_API FDataInitiateFileUploadsRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Names of the files to be set. Restricted to a-Z, 0-9, '(', ')', '_', '-' and '.' */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
         FString FileNames;
@@ -208,13 +208,13 @@ struct PLAYFAB_API FDataInitiateFileUploadsResponse : public FPlayFabResultCommo
 public:
     /** The entity id and type. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The current version of the profile, can be used for concurrency control during updates. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
         int32 ProfileVersion = 0;
     /** Collection of file names and upload urls */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | File Models")
-        TArray<UPlayFabJsonObject*> UploadDetails;
+        TArray<TObjectPtr<UPlayFabJsonObject>> UploadDetails;
 };
 
 
@@ -230,10 +230,10 @@ struct PLAYFAB_API FDataGetObjectsRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | Object Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | Object Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * Determines whether the object will be returned as an escaped JSON string or as a un-escaped JSON object. Default is JSON
      * object.
@@ -249,10 +249,10 @@ struct PLAYFAB_API FDataGetObjectsResponse : public FPlayFabResultCommon
 public:
     /** The entity id and type. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | Object Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Requested objects that the calling entity has access to */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | Object Models")
-        UPlayFabJsonObject* Objects = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Objects;
     /** The current version of the profile, can be used for concurrency control during updates. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | Object Models")
         int32 ProfileVersion = 0;
@@ -272,10 +272,10 @@ struct PLAYFAB_API FDataSetObjectsRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | Object Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | Object Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * Optional field used for concurrency control. By specifying the previously returned value of ProfileVersion from
      * GetProfile API, you can ensure that the object set will only be performed if the profile has not been updated by any
@@ -285,7 +285,7 @@ public:
         int32 ExpectedProfileVersion = 0;
     /** Collection of objects to set on the profile. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | Object Models")
-        TArray<UPlayFabJsonObject*> Objects;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Objects;
 };
 
 USTRUCT(BlueprintType)
@@ -298,6 +298,6 @@ public:
         int32 ProfileVersion = 0;
     /** New version of the entity profile. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Data | Object Models")
-        TArray<UPlayFabJsonObject*> SetResults;
+        TArray<TObjectPtr<UPlayFabJsonObject>> SetResults;
 };
 

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabEconomyAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabEconomyAPI.h
@@ -831,7 +831,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -839,11 +839,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabEconomyModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabEconomyModels.h
@@ -38,10 +38,10 @@ struct PLAYFAB_API FEconomyCreateDraftItemRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Metadata describing the new catalog item to be created. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Item = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Item;
     /** Whether the item should be published immediately. This value is optional, defaults to false. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         bool Publish = false;
@@ -54,7 +54,7 @@ struct PLAYFAB_API FEconomyCreateDraftItemResponse : public FPlayFabResultCommon
 public:
     /** Updated metadata describing the catalog item just created. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Item = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Item;
 };
 
 /**
@@ -69,10 +69,10 @@ struct PLAYFAB_API FEconomyCreateUploadUrlsRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Description of the files to be uploaded by the client. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        TArray<UPlayFabJsonObject*> Files;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Files;
 };
 
 USTRUCT(BlueprintType)
@@ -82,7 +82,7 @@ struct PLAYFAB_API FEconomyCreateUploadUrlsResponse : public FPlayFabResultCommo
 public:
     /** List of URLs metadata for the files to be uploaded by the client. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        TArray<UPlayFabJsonObject*> UploadUrls;
+        TArray<TObjectPtr<UPlayFabJsonObject>> UploadUrls;
 };
 
 USTRUCT(BlueprintType)
@@ -92,10 +92,10 @@ struct PLAYFAB_API FEconomyDeleteEntityItemReviewsRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
 };
 
 USTRUCT(BlueprintType)
@@ -112,13 +112,13 @@ struct PLAYFAB_API FEconomyDeleteItemRequest : public FPlayFabRequestCommon
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
@@ -138,7 +138,7 @@ struct PLAYFAB_API FEconomyGetCatalogConfigRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -148,7 +148,7 @@ struct PLAYFAB_API FEconomyGetCatalogConfigResponse : public FPlayFabResultCommo
 public:
     /** The catalog configuration. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Config = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Config;
 };
 
 USTRUCT(BlueprintType)
@@ -158,13 +158,13 @@ struct PLAYFAB_API FEconomyGetDraftItemRequest : public FPlayFabRequestCommon
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
@@ -177,7 +177,7 @@ struct PLAYFAB_API FEconomyGetDraftItemResponse : public FPlayFabResultCommon
 public:
     /** Full metadata of the catalog item requested. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Item = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Item;
 };
 
 USTRUCT(BlueprintType)
@@ -187,7 +187,7 @@ struct PLAYFAB_API FEconomyGetDraftItemsRequest : public FPlayFabRequestCommon
 public:
     /** List of item alternate IDs. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        TArray<UPlayFabJsonObject*> AlternateIds;
+        TArray<TObjectPtr<UPlayFabJsonObject>> AlternateIds;
     /**
      * An opaque token used to retrieve the next page of items created by the caller, if any are available. Should be null on
      * initial request.
@@ -199,10 +199,10 @@ public:
         int32 Count = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** List of Item Ids. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Ids;
@@ -218,7 +218,7 @@ public:
         FString ContinuationToken;
     /** A set of items created by the entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
 };
 
 USTRUCT(BlueprintType)
@@ -237,10 +237,10 @@ public:
         int32 Count = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * OData Filter to refine the items returned. CatalogItem properties 'type' can be used in the filter. For example: "type
      * eq 'ugc'"
@@ -259,7 +259,7 @@ public:
         FString ContinuationToken;
     /** A set of items created by the entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
 };
 
 USTRUCT(BlueprintType)
@@ -269,13 +269,13 @@ struct PLAYFAB_API FEconomyGetEntityItemReviewRequest : public FPlayFabRequestCo
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
@@ -288,7 +288,7 @@ struct PLAYFAB_API FEconomyGetEntityItemReviewResponse : public FPlayFabResultCo
 public:
     /** The review the entity submitted for the requested item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Review = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Review;
 };
 
 USTRUCT(BlueprintType)
@@ -298,13 +298,13 @@ struct PLAYFAB_API FEconomyGetItemRequest : public FPlayFabRequestCommon
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
@@ -318,7 +318,7 @@ struct PLAYFAB_API FEconomyGetItemResponse : public FPlayFabResultCommon
 public:
     /** The item result. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Item = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Item;
 };
 
 /** Given an item, return a set of bundles and stores containing the item. */
@@ -329,7 +329,7 @@ struct PLAYFAB_API FEconomyGetItemContainersRequest : public FPlayFabRequestComm
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /**
      * An opaque token used to retrieve the next page of items in the inventory, if any are available. Should be null on
      * initial request.
@@ -341,10 +341,10 @@ public:
         int32 Count = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
@@ -357,7 +357,7 @@ struct PLAYFAB_API FEconomyGetItemContainersResponse : public FPlayFabResultComm
 public:
     /** List of Bundles and Stores containing the requested items. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        TArray<UPlayFabJsonObject*> Containers;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Containers;
     /** An opaque token used to retrieve the next page of items, if any are available. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString ContinuationToken;
@@ -370,10 +370,10 @@ struct PLAYFAB_API FEconomyGetItemModerationStateRequest : public FPlayFabReques
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
@@ -386,7 +386,7 @@ struct PLAYFAB_API FEconomyGetItemModerationStateResponse : public FPlayFabResul
 public:
     /** The current moderation state for the requested item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* State = nullptr;
+        TObjectPtr<UPlayFabJsonObject> State;
 };
 
 USTRUCT(BlueprintType)
@@ -396,13 +396,13 @@ struct PLAYFAB_API FEconomyGetItemPublishStatusRequest : public FPlayFabRequestC
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
@@ -428,7 +428,7 @@ struct PLAYFAB_API FEconomyGetItemReviewsRequest : public FPlayFabRequestCommon
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** An opaque token used to retrieve the next page of items, if any are available. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString ContinuationToken;
@@ -437,7 +437,7 @@ public:
         int32 Count = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
@@ -459,7 +459,7 @@ public:
         FString ContinuationToken;
     /** The paginated set of results. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        TArray<UPlayFabJsonObject*> Reviews;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Reviews;
 };
 
 USTRUCT(BlueprintType)
@@ -469,10 +469,10 @@ struct PLAYFAB_API FEconomyGetItemReviewSummaryRequest : public FPlayFabRequestC
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
@@ -485,13 +485,13 @@ struct PLAYFAB_API FEconomyGetItemReviewSummaryResponse : public FPlayFabResultC
 public:
     /** The least favorable review for this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* LeastFavorableReview = nullptr;
+        TObjectPtr<UPlayFabJsonObject> LeastFavorableReview;
     /** The most favorable review for this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* MostFavorableReview = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MostFavorableReview;
     /** The summary of ratings associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Rating = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Rating;
     /** The total number of reviews associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         int32 ReviewsCount = 0;
@@ -504,13 +504,13 @@ struct PLAYFAB_API FEconomyGetItemsRequest : public FPlayFabRequestCommon
 public:
     /** List of item alternate IDs. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        TArray<UPlayFabJsonObject*> AlternateIds;
+        TArray<TObjectPtr<UPlayFabJsonObject>> AlternateIds;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** List of Item Ids. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Ids;
@@ -523,7 +523,7 @@ struct PLAYFAB_API FEconomyGetItemsResponse : public FPlayFabResultCommon
 public:
     /** Metadata of set of items. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
 };
 
 /**
@@ -537,13 +537,13 @@ struct PLAYFAB_API FEconomyPublishDraftItemRequest : public FPlayFabRequestCommo
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * ETag of the catalog item to published from the working catalog to the public catalog. Used for optimistic concurrency.
      * If the provided ETag does not match the ETag in the current working catalog, the request will be rejected. If not
@@ -570,16 +570,16 @@ struct PLAYFAB_API FEconomyReportItemRequest : public FPlayFabRequestCommon
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** Category of concern for this report. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         EConcernCategory ConcernCategory = StaticCast<EConcernCategory>(0);
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
@@ -603,16 +603,16 @@ struct PLAYFAB_API FEconomyReportItemReviewRequest : public FPlayFabRequestCommo
 public:
     /** An alternate ID of the item associated with the review. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The reason this review is being reported. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         EConcernCategory ConcernCategory = StaticCast<EConcernCategory>(0);
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The string ID of the item associated with the review. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString ItemId;
@@ -638,19 +638,19 @@ struct PLAYFAB_API FEconomyReviewItemRequest : public FPlayFabRequestCommon
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
     /** The review to submit. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Review = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Review;
 };
 
 USTRUCT(BlueprintType)
@@ -673,10 +673,10 @@ public:
         int32 Count = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * An OData filter used to refine the search query (For example: "type eq 'ugc'"). More info about Filter Complexity limits
      * can be found here: https://learn.microsoft.com/en-us/gaming/playfab/features/economy-v2/catalog/search#limits
@@ -700,7 +700,7 @@ public:
         FString Select;
     /** The store to restrict the search request to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Store = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Store;
 };
 
 USTRUCT(BlueprintType)
@@ -713,7 +713,7 @@ public:
         FString ContinuationToken;
     /** The paginated set of results for the search query. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
 };
 
 USTRUCT(BlueprintType)
@@ -723,10 +723,10 @@ struct PLAYFAB_API FEconomySetItemModerationStateRequest : public FPlayFabReques
 public:
     /** An alternate ID associated with this item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The unique ID of the item. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString Id;
@@ -752,13 +752,13 @@ struct PLAYFAB_API FEconomySubmitItemReviewVoteRequest : public FPlayFabRequestC
 public:
     /** An alternate ID of the item associated with the review. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* AlternateId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> AlternateId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The string ID of the item associated with the review. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         FString ItemId;
@@ -788,10 +788,10 @@ struct PLAYFAB_API FEconomyTakedownItemReviewsRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The set of reviews to take down. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        TArray<UPlayFabJsonObject*> Reviews;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Reviews;
 };
 
 USTRUCT(BlueprintType)
@@ -808,10 +808,10 @@ struct PLAYFAB_API FEconomyUpdateCatalogConfigRequest : public FPlayFabRequestCo
 public:
     /** The updated catalog configuration. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Config = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Config;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -828,10 +828,10 @@ struct PLAYFAB_API FEconomyUpdateDraftItemRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Updated metadata describing the catalog item to be updated. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Item = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Item;
     /** Whether the item should be published immediately. This value is optional, defaults to false. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
         bool Publish = false;
@@ -844,7 +844,7 @@ struct PLAYFAB_API FEconomyUpdateDraftItemResponse : public FPlayFabResultCommon
 public:
     /** Updated metadata describing the catalog item just updated. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Catalog Models")
-        UPlayFabJsonObject* Item = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Item;
 };
 
 
@@ -869,13 +869,13 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The duration to add to the current item expiration date. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         int32 DurationInSeconds = 0;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * ETags are used for concurrency checking when updating resources. More information about using ETags can be found here:
      * https://learn.microsoft.com/en-us/gaming/playfab/features/economy-v2/catalog/etags
@@ -890,10 +890,10 @@ public:
         FString IdempotencyId;
     /** The inventory item the request applies to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Item = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Item;
     /** The values to apply to a stack newly created by this request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* NewStackValues = nullptr;
+        TObjectPtr<UPlayFabJsonObject> NewStackValues;
 };
 
 USTRUCT(BlueprintType)
@@ -926,10 +926,10 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity the request is about. Set to the caller by default. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * ETags are used for concurrency checking when updating resources. More information about using ETags can be found here:
      * https://learn.microsoft.com/en-us/gaming/playfab/features/economy-v2/catalog/etags
@@ -959,10 +959,10 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * ETags are used for concurrency checking when updating resources. More information about using ETags can be found here:
      * https://learn.microsoft.com/en-us/gaming/playfab/features/economy-v2/catalog/etags
@@ -977,7 +977,7 @@ public:
         FString IdempotencyId;
     /** The inventory item the request applies to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Item = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Item;
 };
 
 USTRUCT(BlueprintType)
@@ -1010,10 +1010,10 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * ETags are used for concurrency checking when updating resources. More information about using ETags can be found here:
      * https://learn.microsoft.com/en-us/gaming/playfab/features/economy-v2/catalog/etags
@@ -1031,7 +1031,7 @@ public:
      * a batch. Up to 50 operations can be added.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Operations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Operations;
 };
 
 USTRUCT(BlueprintType)
@@ -1061,13 +1061,13 @@ struct PLAYFAB_API FEconomyExecuteTransferOperationsRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The inventory collection id the request is transferring from. (Default="default") */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString GivingCollectionId;
     /** The entity the request is transferring from. Set to the caller by default. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* GivingEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> GivingEntity;
     /**
      * ETags are used for concurrency checking when updating resources. More information about using ETags can be found here:
      * https://learn.microsoft.com/en-us/gaming/playfab/features/economy-v2/catalog/etags
@@ -1082,13 +1082,13 @@ public:
      * or fail as a batch. Up to 50 operations can be added.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Operations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Operations;
     /** The inventory collection id the request is transferring to. (Default="default") */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString ReceivingCollectionId;
     /** The entity the request is transferring to. Set to the caller by default. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* ReceivingEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ReceivingEntity;
 };
 
 USTRUCT(BlueprintType)
@@ -1146,10 +1146,10 @@ public:
         int32 Count = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity the request is about. Set to the caller by default. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
 };
 
 USTRUCT(BlueprintType)
@@ -1185,10 +1185,10 @@ public:
         int32 Count = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * OData Filter to refine the items returned. InventoryItem properties 'type', 'id', and 'stackId' can be used in the
      * filter. For example: "type eq 'currency'"
@@ -1213,7 +1213,7 @@ public:
         FString ETag;
     /** The requested inventory items. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
 };
 
 /** Get the status of an Inventory Operation using an OperationToken. */
@@ -1227,10 +1227,10 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The token to get the status of the inventory operation. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString OperationToken;
@@ -1263,10 +1263,10 @@ public:
         int32 Count = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * An OData filter used to refine the TransactionHistory. Transaction properties 'timestamp', 'transactionid', 'apiname'
      * and 'operationtype' can be used in the filter. Properties 'transactionid', 'apiname', and 'operationtype' cannot be used
@@ -1294,7 +1294,7 @@ public:
         FString ContinuationToken;
     /** The requested inventory transactions. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Transactions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Transactions;
 };
 
 /** Purchase a single item or bundle, paying the associated price. */
@@ -1314,7 +1314,7 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Indicates whether stacks reduced to an amount of 0 during the request should be deleted from the inventory.
      * (Default=false)
@@ -1326,7 +1326,7 @@ public:
         int32 DurationInSeconds = 0;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * ETags are used for concurrency checking when updating resources. More information about using ETags can be found here:
      * https://learn.microsoft.com/en-us/gaming/playfab/features/economy-v2/catalog/etags
@@ -1341,16 +1341,16 @@ public:
         FString IdempotencyId;
     /** The inventory item the request applies to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Item = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Item;
     /** The values to apply to a stack newly created by this request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* NewStackValues = nullptr;
+        TObjectPtr<UPlayFabJsonObject> NewStackValues;
     /**
      * The per-item price the item is expected to be purchased at. This must match a value configured in the Catalog or
      * specified Store.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> PriceAmounts;
+        TArray<TObjectPtr<UPlayFabJsonObject>> PriceAmounts;
     /** The id of the Store to purchase the item from. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString StoreId;
@@ -1386,10 +1386,10 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The receipt provided by the Apple marketplace upon successful purchase. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString Receipt;
@@ -1402,10 +1402,10 @@ struct PLAYFAB_API FEconomyRedeemAppleAppStoreInventoryItemsResponse : public FP
 public:
     /** The list of failed redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Failed;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Failed;
     /** The list of successful redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Succeeded;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Succeeded;
     /** The Transaction IDs associated with the inventory modifications */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString TransactionIds;
@@ -1422,10 +1422,10 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The JWS representation of a transaction. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString JWSTransactions;
@@ -1439,10 +1439,10 @@ struct PLAYFAB_API FEconomyRedeemAppleAppStoreWithJwsInventoryItemsResponse : pu
 public:
     /** The list of failed redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Failed;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Failed;
     /** The list of successful redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Succeeded;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Succeeded;
     /** The Transaction IDs associated with the inventory modifications */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString TransactionIds;
@@ -1459,13 +1459,13 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The list of purchases to redeem */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Purchases;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Purchases;
 };
 
 USTRUCT(BlueprintType)
@@ -1475,10 +1475,10 @@ struct PLAYFAB_API FEconomyRedeemGooglePlayInventoryItemsResponse : public FPlay
 public:
     /** The list of failed redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Failed;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Failed;
     /** The list of successful redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Succeeded;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Succeeded;
     /** The Transaction IDs associated with the inventory modifications */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString TransactionIds;
@@ -1495,10 +1495,10 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * Xbox Token used for delegated business partner authentication. Token provided by the Xbox Live SDK method
      * GetTokenAndSignatureAsync("POST", "https://playfabapi.com/", "").
@@ -1514,10 +1514,10 @@ struct PLAYFAB_API FEconomyRedeemMicrosoftStoreInventoryItemsResponse : public F
 public:
     /** The list of failed redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Failed;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Failed;
     /** The list of successful redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Succeeded;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Succeeded;
     /** The Transaction IDs associated with the inventory modifications */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString TransactionIds;
@@ -1534,10 +1534,10 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The Nintendo provided token authorizing redemption */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString NintendoServiceAccountIdToken;
@@ -1550,10 +1550,10 @@ struct PLAYFAB_API FEconomyRedeemNintendoEShopInventoryItemsResponse : public FP
 public:
     /** The list of failed redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Failed;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Failed;
     /** The list of successful redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Succeeded;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Succeeded;
     /** The Transaction IDs associated with the inventory modifications */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString TransactionIds;
@@ -1573,10 +1573,10 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Redirect URI supplied to PlayStation :tm: Network when requesting an auth code. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString RedirectUri;
@@ -1592,10 +1592,10 @@ struct PLAYFAB_API FEconomyRedeemPlayStationStoreInventoryItemsResponse : public
 public:
     /** The list of failed redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Failed;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Failed;
     /** The list of successful redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Succeeded;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Succeeded;
     /** The Transaction IDs associated with the inventory modifications */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString TransactionIds;
@@ -1612,10 +1612,10 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
 };
 
 USTRUCT(BlueprintType)
@@ -1625,10 +1625,10 @@ struct PLAYFAB_API FEconomyRedeemSteamInventoryItemsResponse : public FPlayFabRe
 public:
     /** The list of failed redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Failed;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Failed;
     /** The list of successful redemptions from the external marketplace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        TArray<UPlayFabJsonObject*> Succeeded;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Succeeded;
     /** The Transaction IDs associated with the inventory modifications */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString TransactionIds;
@@ -1651,7 +1651,7 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Indicates whether stacks reduced to an amount of 0 during the request should be deleted from the inventory.
      * (Default=false)
@@ -1663,7 +1663,7 @@ public:
         int32 DurationInSeconds = 0;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * ETags are used for concurrency checking when updating resources. More information about using ETags can be found here:
      * https://learn.microsoft.com/en-us/gaming/playfab/features/economy-v2/catalog/etags
@@ -1678,7 +1678,7 @@ public:
         FString IdempotencyId;
     /** The inventory item the request applies to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Item = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Item;
 };
 
 USTRUCT(BlueprintType)
@@ -1711,7 +1711,7 @@ public:
         int32 Amount = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Indicates whether stacks reduced to an amount of 0 during the request should be deleted from the inventory. (Default =
      * false)
@@ -1723,7 +1723,7 @@ public:
         FString GivingCollectionId;
     /** The entity the request is transferring from. Set to the caller by default. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* GivingEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> GivingEntity;
     /**
      * ETags are used for concurrency checking when updating resources (before transferring from). More information about using
      * ETags can be found here: https://learn.microsoft.com/en-us/gaming/playfab/features/economy-v2/catalog/etags
@@ -1732,22 +1732,22 @@ public:
         FString GivingETag;
     /** The inventory item the request is transferring from. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* GivingItem = nullptr;
+        TObjectPtr<UPlayFabJsonObject> GivingItem;
     /** The idempotency id for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString IdempotencyId;
     /** The values to apply to a stack newly created by this request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* NewStackValues = nullptr;
+        TObjectPtr<UPlayFabJsonObject> NewStackValues;
     /** The inventory collection id the request is transferring to. (Default="default") */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
         FString ReceivingCollectionId;
     /** The entity the request is transferring to. Set to the caller by default. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* ReceivingEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ReceivingEntity;
     /** The inventory item the request is transferring to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* ReceivingItem = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ReceivingItem;
 };
 
 USTRUCT(BlueprintType)
@@ -1798,10 +1798,10 @@ public:
         FString CollectionId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * ETags are used for concurrency checking when updating resources. More information about using ETags can be found here:
      * https://learn.microsoft.com/en-us/gaming/playfab/features/economy-v2/catalog/etags
@@ -1816,7 +1816,7 @@ public:
         FString IdempotencyId;
     /** The inventory item to update with the specified values. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Economy | Inventory Models")
-        UPlayFabJsonObject* Item = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Item;
 };
 
 USTRUCT(BlueprintType)

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabEnums.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabEnums.h
@@ -61,7 +61,7 @@ static FORCEINLINE bool GetEnumValueToString(const FString& enumTypeName, const 
     output = enumPtr->GetNameStringByIndex((int32)input);
 #endif
     if (output.StartsWith(*prefix))
-        output.RemoveAt(0, 7, false);
+        output.RemoveAt(0, 7, EAllowShrinking::No);
     return true;
 }
 

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabEventsAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabEventsAPI.h
@@ -276,7 +276,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -284,11 +284,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabEventsModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabEventsModels.h
@@ -42,10 +42,10 @@ struct PLAYFAB_API FEventsCreateTelemetryKeyRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The name of the new key. Telemetry key names must be unique within the scope of the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
         FString KeyName;
@@ -58,7 +58,7 @@ struct PLAYFAB_API FEventsCreateTelemetryKeyResponse : public FPlayFabResultComm
 public:
     /** Details about the newly created telemetry key. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* NewKeyDetails = nullptr;
+        TObjectPtr<UPlayFabJsonObject> NewKeyDetails;
 };
 
 USTRUCT(BlueprintType)
@@ -68,7 +68,7 @@ struct PLAYFAB_API FEventsDeleteDataConnectionRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the data connection to delete. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
         FString Name;
@@ -91,10 +91,10 @@ struct PLAYFAB_API FEventsDeleteTelemetryKeyRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The name of the key to delete. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
         FString KeyName;
@@ -117,7 +117,7 @@ struct PLAYFAB_API FEventsGetDataConnectionRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the data connection to retrieve. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
         FString Name;
@@ -130,7 +130,7 @@ struct PLAYFAB_API FEventsGetDataConnectionResponse : public FPlayFabResultCommo
 public:
     /** The details of the queried Data Connection. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* DataConnection = nullptr;
+        TObjectPtr<UPlayFabJsonObject> DataConnection;
 };
 
 USTRUCT(BlueprintType)
@@ -140,10 +140,10 @@ struct PLAYFAB_API FEventsGetTelemetryKeyRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The name of the key to retrieve. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
         FString KeyName;
@@ -156,7 +156,7 @@ struct PLAYFAB_API FEventsGetTelemetryKeyResponse : public FPlayFabResultCommon
 public:
     /** Details about the requested telemetry key. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* KeyDetails = nullptr;
+        TObjectPtr<UPlayFabJsonObject> KeyDetails;
 };
 
 USTRUCT(BlueprintType)
@@ -166,7 +166,7 @@ struct PLAYFAB_API FEventsListDataConnectionsRequest : public FPlayFabRequestCom
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -176,7 +176,7 @@ struct PLAYFAB_API FEventsListDataConnectionsResponse : public FPlayFabResultCom
 public:
     /** The list of existing Data Connections. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        TArray<UPlayFabJsonObject*> DataConnections;
+        TArray<TObjectPtr<UPlayFabJsonObject>> DataConnections;
 };
 
 USTRUCT(BlueprintType)
@@ -186,10 +186,10 @@ struct PLAYFAB_API FEventsListTelemetryKeysRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
 };
 
 USTRUCT(BlueprintType)
@@ -199,7 +199,7 @@ struct PLAYFAB_API FEventsListTelemetryKeysResponse : public FPlayFabResultCommo
 public:
     /** The telemetry keys configured for the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        TArray<UPlayFabJsonObject*> KeyDetails;
+        TArray<TObjectPtr<UPlayFabJsonObject>> KeyDetails;
 };
 
 USTRUCT(BlueprintType)
@@ -209,10 +209,10 @@ struct PLAYFAB_API FEventsSetDataConnectionRequest : public FPlayFabRequestCommo
 public:
     /** Settings of the data connection. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* ConnectionSettings = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ConnectionSettings;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Whether or not the connection is currently active. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
         bool IsActive = false;
@@ -231,7 +231,7 @@ struct PLAYFAB_API FEventsSetDataConnectionResponse : public FPlayFabResultCommo
 public:
     /** The details of the Data Connection to be created or updated. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* DataConnection = nullptr;
+        TObjectPtr<UPlayFabJsonObject> DataConnection;
 };
 
 USTRUCT(BlueprintType)
@@ -244,7 +244,7 @@ public:
         bool Active = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the data connection to update. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
         FString Name;
@@ -257,7 +257,7 @@ struct PLAYFAB_API FEventsSetDataConnectionActiveResponse : public FPlayFabResul
 public:
     /** The most current details about the data connection that was to be updated. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* DataConnection = nullptr;
+        TObjectPtr<UPlayFabJsonObject> DataConnection;
     /**
      * Indicates whether or not the data connection was updated. If false, the data connection was already in the desired
      * state.
@@ -276,10 +276,10 @@ public:
         bool Active = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The name of the key to update. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
         FString KeyName;
@@ -292,7 +292,7 @@ struct PLAYFAB_API FEventsSetTelemetryKeyActiveResponse : public FPlayFabResultC
 public:
     /** The most current details about the telemetry key that was to be updated. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* KeyDetails = nullptr;
+        TObjectPtr<UPlayFabJsonObject> KeyDetails;
     /** Indicates whether or not the key was updated. If false, the key was already in the desired state. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
         bool WasKeyUpdated = false;
@@ -305,10 +305,10 @@ struct PLAYFAB_API FEventsWriteEventsRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The collection of events to write. Up to 200 events can be written per request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Events | PlayStream Events Models")
-        TArray<UPlayFabJsonObject*> Events;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Events;
 };
 
 USTRUCT(BlueprintType)

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabExperimentationAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabExperimentationAPI.h
@@ -261,7 +261,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -269,11 +269,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabExperimentationModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabExperimentationModels.h
@@ -38,7 +38,7 @@ struct PLAYFAB_API FExperimentationCreateExclusionGroupRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Description of the exclusion group. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
         FString Description;
@@ -65,7 +65,7 @@ struct PLAYFAB_API FExperimentationCreateExperimentRequest : public FPlayFabRequ
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Description of the experiment. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
         FString Description;
@@ -98,7 +98,7 @@ public:
         FString TitlePlayerAccountTestIds;
     /** List of variants for the experiment. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        TArray<UPlayFabJsonObject*> Variants;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Variants;
 };
 
 USTRUCT(BlueprintType)
@@ -119,7 +119,7 @@ struct PLAYFAB_API FExperimentationDeleteExclusionGroupRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The ID of the exclusion group to delete. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
         FString ExclusionGroupId;
@@ -143,7 +143,7 @@ struct PLAYFAB_API FExperimentationDeleteExperimentRequest : public FPlayFabRequ
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The ID of the experiment to delete. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
         FString ExperimentId;
@@ -157,7 +157,7 @@ struct PLAYFAB_API FExperimentationGetExclusionGroupsRequest : public FPlayFabRe
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -167,7 +167,7 @@ struct PLAYFAB_API FExperimentationGetExclusionGroupsResult : public FPlayFabRes
 public:
     /** List of exclusion groups for the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        TArray<UPlayFabJsonObject*> ExclusionGroups;
+        TArray<TObjectPtr<UPlayFabJsonObject>> ExclusionGroups;
 };
 
 /**
@@ -181,7 +181,7 @@ struct PLAYFAB_API FExperimentationGetExclusionGroupTrafficRequest : public FPla
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The ID of the exclusion group. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
         FString ExclusionGroupId;
@@ -194,7 +194,7 @@ struct PLAYFAB_API FExperimentationGetExclusionGroupTrafficResult : public FPlay
 public:
     /** List of traffic allocations for the exclusion group. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        TArray<UPlayFabJsonObject*> TrafficAllocations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> TrafficAllocations;
 };
 
 /**
@@ -208,7 +208,7 @@ struct PLAYFAB_API FExperimentationGetExperimentsRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -218,7 +218,7 @@ struct PLAYFAB_API FExperimentationGetExperimentsResult : public FPlayFabResultC
 public:
     /** List of experiments for the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        TArray<UPlayFabJsonObject*> Experiments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Experiments;
 };
 
 /** Given a title entity token and experiment details, will return the latest available scorecard. */
@@ -229,7 +229,7 @@ struct PLAYFAB_API FExperimentationGetLatestScorecardRequest : public FPlayFabRe
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The ID of the experiment. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
         FString ExperimentId;
@@ -242,7 +242,7 @@ struct PLAYFAB_API FExperimentationGetLatestScorecardResult : public FPlayFabRes
 public:
     /** Scorecard for the experiment of the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* Scorecard = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Scorecard;
 };
 
 /**
@@ -256,10 +256,10 @@ struct PLAYFAB_API FExperimentationGetTreatmentAssignmentRequest : public FPlayF
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
 };
 
 USTRUCT(BlueprintType)
@@ -269,7 +269,7 @@ struct PLAYFAB_API FExperimentationGetTreatmentAssignmentResult : public FPlayFa
 public:
     /** Treatment assignment for the entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* TreatmentAssignment = nullptr;
+        TObjectPtr<UPlayFabJsonObject> TreatmentAssignment;
 };
 
 /** Given a title entity token and an experiment ID, this API starts the experiment. */
@@ -280,7 +280,7 @@ struct PLAYFAB_API FExperimentationStartExperimentRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The ID of the experiment to start. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
         FString ExperimentId;
@@ -294,7 +294,7 @@ struct PLAYFAB_API FExperimentationStopExperimentRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The ID of the experiment to stop. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
         FString ExperimentId;
@@ -308,7 +308,7 @@ struct PLAYFAB_API FExperimentationUpdateExclusionGroupRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Description of the exclusion group. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
         FString Description;
@@ -331,7 +331,7 @@ struct PLAYFAB_API FExperimentationUpdateExperimentRequest : public FPlayFabRequ
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Description of the experiment. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
         FString Description;
@@ -367,6 +367,6 @@ public:
         FString TitlePlayerAccountTestIds;
     /** List of variants for the experiment. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Experimentation | Experimentation Models")
-        TArray<UPlayFabJsonObject*> Variants;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Variants;
 };
 

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabGroupsAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabGroupsAPI.h
@@ -429,7 +429,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -437,11 +437,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabGroupsModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabGroupsModels.h
@@ -41,16 +41,16 @@ struct PLAYFAB_API FGroupsAcceptGroupApplicationRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Type of the entity to accept as. Must be the same entity as the claimant or an entity that is a child of the claimant
      * entity.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 USTRUCT(BlueprintType)
@@ -72,13 +72,13 @@ struct PLAYFAB_API FGroupsAcceptGroupInvitationRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 /**
@@ -93,13 +93,13 @@ struct PLAYFAB_API FGroupsAddMembersRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /** List of entities to add to the group. Only entities of type title_player_account and character may be added to groups. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        TArray<UPlayFabJsonObject*> Members;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Members;
     /**
      * Optional: The ID of the existing role to add the entities to. If this is not specified, the default member role for the
      * group will be used. Role IDs must be between 1 and 64 characters long.
@@ -125,13 +125,13 @@ public:
         bool AutoAcceptOutstandingInvite = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 /** Describes an application to join a group */
@@ -142,13 +142,13 @@ struct PLAYFAB_API FGroupsApplyToGroupResponse : public FPlayFabResultCommon
 public:
     /** Type of entity that requested membership */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** When the application to join will expire and be deleted */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
         FString Expires;
     /** ID of the group that the entity requesting membership to */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 /**
@@ -163,13 +163,13 @@ struct PLAYFAB_API FGroupsBlockEntityRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 /**
@@ -184,7 +184,7 @@ struct PLAYFAB_API FGroupsChangeMemberRoleRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The ID of the role that the entities will become a member of. This must be an existing role. Role IDs must be between 1
      * and 64 characters long.
@@ -193,13 +193,13 @@ public:
         FString DestinationRoleId;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /**
      * List of entities to move between roles in the group. All entities in this list must be members of the group and origin
      * role.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        TArray<UPlayFabJsonObject*> Members;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Members;
     /** The ID of the role that the entities currently are a member of. Role IDs must be between 1 and 64 characters long. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
         FString OriginRoleId;
@@ -216,10 +216,10 @@ struct PLAYFAB_API FGroupsCreateGroupRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The name of the group. This is unique at the title level by default. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
         FString GroupName;
@@ -238,7 +238,7 @@ public:
         FString Created;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /** The name of the group. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
         FString GroupName;
@@ -250,7 +250,7 @@ public:
         int32 ProfileVersion = 0;
     /** The list of roles and names that belong to the group. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Roles = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Roles;
 };
 
 /**
@@ -265,10 +265,10 @@ struct PLAYFAB_API FGroupsCreateGroupRoleRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /**
      * The ID of the role. This must be unique within the group and cannot be changed. Role IDs must be between 1 and 64
      * characters long and are restricted to a-Z, A-Z, 0-9, '(', ')', '_', '-' and '.'.
@@ -311,10 +311,10 @@ struct PLAYFAB_API FGroupsDeleteGroupRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** ID of the group or role to remove */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 /** Returns information about the role */
@@ -325,10 +325,10 @@ struct PLAYFAB_API FGroupsDeleteRoleRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /** The ID of the role to delete. Role IDs must be between 1 and 64 characters long. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
         FString RoleId;
@@ -342,10 +342,10 @@ struct PLAYFAB_API FGroupsGetGroupRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /** The full name of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
         FString GroupName;
@@ -364,7 +364,7 @@ public:
         FString Created;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /** The name of the group. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
         FString GroupName;
@@ -376,7 +376,7 @@ public:
         int32 ProfileVersion = 0;
     /** The list of roles and names that belong to the group. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Roles = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Roles;
 };
 
 /**
@@ -396,13 +396,13 @@ public:
         bool AutoAcceptOutstandingApplication = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /**
      * Optional. ID of an existing a role in the group to assign the user to. The group's default member role is used if this
      * is not specified. Role IDs must be between 1 and 64 characters long.
@@ -422,13 +422,13 @@ public:
         FString Expires;
     /** The group that the entity invited to */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /** The entity that created the invitation */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* InvitedByEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InvitedByEntity;
     /** The entity that is invited */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* InvitedEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InvitedEntity;
     /** ID of the role in the group to assign the user to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
         FString RoleId;
@@ -446,13 +446,13 @@ struct PLAYFAB_API FGroupsIsMemberRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /**
      * Optional: ID of the role to check membership of. Defaults to any role (that is, check to see if the entity is a member
      * of the group in any capacity) if not specified.
@@ -482,10 +482,10 @@ struct PLAYFAB_API FGroupsListGroupApplicationsRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 USTRUCT(BlueprintType)
@@ -495,7 +495,7 @@ struct PLAYFAB_API FGroupsListGroupApplicationsResponse : public FPlayFabResultC
 public:
     /** The requested list of applications to the group. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        TArray<UPlayFabJsonObject*> Applications;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Applications;
 };
 
 /** Lists all entities blocked from joining a group. A list of blocked entities is returned */
@@ -506,10 +506,10 @@ struct PLAYFAB_API FGroupsListGroupBlocksRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 USTRUCT(BlueprintType)
@@ -519,7 +519,7 @@ struct PLAYFAB_API FGroupsListGroupBlocksResponse : public FPlayFabResultCommon
 public:
     /** The requested list blocked entities. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        TArray<UPlayFabJsonObject*> BlockedEntities;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BlockedEntities;
 };
 
 /**
@@ -533,10 +533,10 @@ struct PLAYFAB_API FGroupsListGroupInvitationsRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 USTRUCT(BlueprintType)
@@ -546,7 +546,7 @@ struct PLAYFAB_API FGroupsListGroupInvitationsResponse : public FPlayFabResultCo
 public:
     /** The requested list of group invitations. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        TArray<UPlayFabJsonObject*> Invitations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Invitations;
 };
 
 /**
@@ -561,10 +561,10 @@ struct PLAYFAB_API FGroupsListGroupMembersRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** ID of the group to list the members and roles for */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 USTRUCT(BlueprintType)
@@ -574,7 +574,7 @@ struct PLAYFAB_API FGroupsListGroupMembersResponse : public FPlayFabResultCommon
 public:
     /** The requested list of roles and member entity IDs. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        TArray<UPlayFabJsonObject*> Members;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Members;
 };
 
 /**
@@ -589,10 +589,10 @@ struct PLAYFAB_API FGroupsListMembershipRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
 };
 
 USTRUCT(BlueprintType)
@@ -602,7 +602,7 @@ struct PLAYFAB_API FGroupsListMembershipResponse : public FPlayFabResultCommon
 public:
     /** The list of groups */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        TArray<UPlayFabJsonObject*> Groups;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Groups;
 };
 
 /**
@@ -617,10 +617,10 @@ struct PLAYFAB_API FGroupsListMembershipOpportunitiesRequest : public FPlayFabRe
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
 };
 
 USTRUCT(BlueprintType)
@@ -630,10 +630,10 @@ struct PLAYFAB_API FGroupsListMembershipOpportunitiesResponse : public FPlayFabR
 public:
     /** The requested list of group applications. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        TArray<UPlayFabJsonObject*> Applications;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Applications;
     /** The requested list of group invitations. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        TArray<UPlayFabJsonObject*> Invitations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Invitations;
 };
 
 /**
@@ -648,13 +648,13 @@ struct PLAYFAB_API FGroupsRemoveGroupApplicationRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 /**
@@ -670,13 +670,13 @@ struct PLAYFAB_API FGroupsRemoveGroupInvitationRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 /**
@@ -690,13 +690,13 @@ struct PLAYFAB_API FGroupsRemoveMembersRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /** List of entities to remove */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        TArray<UPlayFabJsonObject*> Members;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Members;
     /** The ID of the role to remove the entities from. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
         FString RoleId;
@@ -710,13 +710,13 @@ struct PLAYFAB_API FGroupsUnblockEntityRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
 };
 
 /**
@@ -733,7 +733,7 @@ public:
         FString AdminRoleId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Optional field used for concurrency control. By specifying the previously returned value of ProfileVersion from the
      * GetGroup API, you can ensure that the group data update will only be performed if the group has not been updated by any
@@ -743,7 +743,7 @@ public:
         int32 ExpectedProfileVersion = 0;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /** Optional: the new name of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
         FString GroupName;
@@ -776,7 +776,7 @@ struct PLAYFAB_API FGroupsUpdateGroupRoleRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Optional field used for concurrency control. By specifying the previously returned value of ProfileVersion from the
      * GetGroup API, you can ensure that the group data update will only be performed if the group has not been updated by any
@@ -786,7 +786,7 @@ public:
         int32 ExpectedProfileVersion = 0;
     /** The identifier of the group */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
-        UPlayFabJsonObject* Group = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Group;
     /** ID of the role to update. Role IDs must be between 1 and 64 characters long. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Groups | Groups Models")
         FString RoleId;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabInsightsAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabInsightsAPI.h
@@ -169,7 +169,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -177,11 +177,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabInsightsModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabInsightsModels.h
@@ -37,7 +37,7 @@ struct PLAYFAB_API FInsightsInsightsEmptyRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -53,10 +53,10 @@ public:
         FString ErrorMessage;
     /** Allowed range of values for performance level and data storage retention. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
-        UPlayFabJsonObject* Limits = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Limits;
     /** List of pending Insights operations for the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
-        TArray<UPlayFabJsonObject*> PendingOperations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> PendingOperations;
     /** Current Insights performance level setting. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
         int32 PerformanceLevel = 0;
@@ -84,7 +84,7 @@ public:
         int32 StorageMinRetentionDays = 0;
     /** List of Insights submeter limits for the allowed performance levels. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
-        TArray<UPlayFabJsonObject*> SubMeters;
+        TArray<TObjectPtr<UPlayFabJsonObject>> SubMeters;
 };
 
 /** Returns the current status for the requested operation id. */
@@ -95,7 +95,7 @@ struct PLAYFAB_API FInsightsInsightsGetOperationStatusRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Id of the Insights operation. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
         FString OperationId;
@@ -140,7 +140,7 @@ struct PLAYFAB_API FInsightsInsightsGetPendingOperationsRequest : public FPlayFa
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The type of pending operations requested, or blank for all operation types. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
         FString OperationType;
@@ -153,7 +153,7 @@ struct PLAYFAB_API FInsightsInsightsGetPendingOperationsResponse : public FPlayF
 public:
     /** List of pending Insights operations. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
-        TArray<UPlayFabJsonObject*> PendingOperations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> PendingOperations;
 };
 
 USTRUCT(BlueprintType)
@@ -180,7 +180,7 @@ struct PLAYFAB_API FInsightsInsightsSetPerformanceRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The Insights performance level to apply to the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
         int32 PerformanceLevel = 0;
@@ -194,7 +194,7 @@ struct PLAYFAB_API FInsightsInsightsSetStorageRetentionRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The Insights data storage retention value (in days) to apply to the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Insights | Analytics Models")
         int32 RetentionDays = 0;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabLocalizationAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabLocalizationAPI.h
@@ -93,7 +93,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -101,11 +101,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabLocalizationModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabLocalizationModels.h
@@ -37,7 +37,7 @@ struct PLAYFAB_API FLocalizationGetLanguageListRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Localization | Localization Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabLoginResultCommon.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabLoginResultCommon.h
@@ -19,5 +19,5 @@ struct PLAYFAB_API FPlayFabLoginResultCommon : public FPlayFabResultCommon
 
     // An authentication context returned by Login methods (can used in multi-user scenarios)
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "PlayFab | Core")
-        UPlayFabAuthenticationContext* AuthenticationContext = nullptr;
+        TObjectPtr<UPlayFabAuthenticationContext> AuthenticationContext;
 };

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabMultiplayerAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabMultiplayerAPI.h
@@ -1262,7 +1262,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -1270,11 +1270,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabMultiplayerModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabMultiplayerModels.h
@@ -47,14 +47,14 @@ public:
         EAccessPolicy AccessPolicy = StaticCast<EAccessPolicy>(0);
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The private key-value pairs which are visible to all entities in the lobby. At most 30 key-value pairs may be stored
      * here, keys are limited to 30 characters and values to 1000. The total size of all lobbyData values may not exceed 4096
      * bytes. Keys are case sensitive.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* LobbyData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> LobbyData;
     /** The maximum number of players allowed in the lobby. The value must be between 2 and 128. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         int32 MaxPlayers = 0;
@@ -63,10 +63,10 @@ public:
      * member data. Member PubSubConnectionHandle must be null or empty. Game servers must not specify any members.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        TArray<UPlayFabJsonObject*> Members;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Members;
     /** The lobby owner. Must be the calling entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* Owner = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Owner;
     /**
      * The policy for how a new owner is chosen. May be 'Automatic', 'Manual' or 'None'. Can only be specified by clients. If
      * client-owned and 'Automatic' - The Lobby service will automatically assign another connected owner when the current
@@ -92,7 +92,7 @@ public:
      * characters long. The total size of all searchData values may not exceed 1024 bytes.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* SearchData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> SearchData;
     /**
      * A setting to control whether connections are used. Defaults to true. When true, notifications are sent to subscribed
      * players, disconnect detection removes connectionHandles, only owner migration policies using connections are allowed,
@@ -125,7 +125,7 @@ struct PLAYFAB_API FMultiplayerDeleteLobbyRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The id of the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         FString LobbyId;
@@ -146,7 +146,7 @@ struct PLAYFAB_API FMultiplayerFindFriendLobbiesRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Indicates which other platforms' friends this query should link to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         EExternalFriendSources ExternalPlatformFriends = StaticCast<EExternalFriendSources>(0);
@@ -172,7 +172,7 @@ public:
         FString OrderBy;
     /** Request pagination information. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* Pagination = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Pagination;
     /**
      * Xbox token if Xbox friends should be included. Requires Xbox be configured on PlayFab. Only mutual Xbox Live friends
      * (where both users follow each other) are included, unlike GetFriendsList which includes all users the caller is
@@ -189,10 +189,10 @@ struct PLAYFAB_API FMultiplayerFindFriendLobbiesResult : public FPlayFabResultCo
 public:
     /** Array of lobbies found that matched FindFriendLobbies request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        TArray<UPlayFabJsonObject*> Lobbies;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Lobbies;
     /** Pagination response for FindFriendLobbies request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* Pagination = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Pagination;
 };
 
 /** Request to find lobbies. */
@@ -203,7 +203,7 @@ struct PLAYFAB_API FMultiplayerFindLobbiesRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * OData style string that contains one or more filters. Only the following operators are supported: "and" (logical and),
      * "eq" (equal), "ne" (not equals), "ge" (greater than or equal), "gt" (greater than), "le" (less than or equal), and "lt"
@@ -226,7 +226,7 @@ public:
         FString OrderBy;
     /** Request pagination information. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* Pagination = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Pagination;
 };
 
 USTRUCT(BlueprintType)
@@ -236,10 +236,10 @@ struct PLAYFAB_API FMultiplayerFindLobbiesResult : public FPlayFabResultCommon
 public:
     /** Array of lobbies found that matched FindLobbies request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        TArray<UPlayFabJsonObject*> Lobbies;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Lobbies;
     /** Pagination response for FindLobbies request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* Pagination = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Pagination;
 };
 
 /** Request to get a lobby. */
@@ -250,7 +250,7 @@ struct PLAYFAB_API FMultiplayerGetLobbyRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The id of the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         FString LobbyId;
@@ -263,7 +263,7 @@ struct PLAYFAB_API FMultiplayerGetLobbyResult : public FPlayFabResultCommon
 public:
     /** The information pertaining to the requested lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* Lobby = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Lobby;
 };
 
 /**
@@ -277,16 +277,16 @@ struct PLAYFAB_API FMultiplayerInviteToLobbyRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity invited to the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* InviteeEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InviteeEntity;
     /** The id of the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         FString LobbyId;
     /** The member entity sending the invite. Must be a member of the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* MemberEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MemberEntity;
 };
 
 /** Request to join an arranged lobby. Only a client can join an arranged lobby. */
@@ -313,7 +313,7 @@ public:
         FString ArrangementString;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The maximum number of players allowed in the lobby. The value must be between 2 and 128. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         int32 MaxPlayers = 0;
@@ -323,10 +323,10 @@ public:
      * 1000. The total size of all memberData values may not exceed 4096 bytes. Keys are case sensitive.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* MemberData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MemberData;
     /** The member entity who is joining the lobby. The first member to join will be the lobby owner. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* MemberEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MemberEntity;
     /**
      * The policy for how a new owner is chosen. May be 'Automatic', 'Manual' or 'None'. Can only be specified by clients. If
      * client-owned and 'Automatic' - The Lobby service will automatically assign another connected owner when the current
@@ -376,17 +376,17 @@ public:
         FString ConnectionString;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The private key-value pairs used by the member to communicate information to other members and the owner. Visible to all
      * entities in the lobby. At most 30 key-value pairs may be stored here, keys are limited to 30 characters and values to
      * 1000. The total size of all memberData values may not exceed 4096 bytes.Keys are case sensitive.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* MemberData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MemberData;
     /** The member entity who is joining the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* MemberEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MemberEntity;
 };
 
 /**
@@ -406,21 +406,21 @@ public:
         FString ConnectionString;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The private key-value pairs which are visible to all entities in the lobby but can only be modified by the joined
      * server.At most 30 key - value pairs may be stored here, keys are limited to 30 characters and values to 1000.The total
      * size of all serverData values may not exceed 4096 bytes.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* ServerData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerData;
     /**
      * The game_server entity which is joining the Lobby. If a different game_server entity has already joined the request will
      * fail unless the joined entity is disconnected, in which case the incoming game_server entity will replace the
      * disconnected entity.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* ServerEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerEntity;
 };
 
 USTRUCT(BlueprintType)
@@ -441,13 +441,13 @@ struct PLAYFAB_API FMultiplayerLeaveLobbyRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The id of the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         FString LobbyId;
     /** The member entity leaving the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* MemberEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MemberEntity;
 };
 
 /**
@@ -461,7 +461,7 @@ struct PLAYFAB_API FMultiplayerLeaveLobbyAsServerRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The id of the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         FString LobbyId;
@@ -470,7 +470,7 @@ public:
      * If a the given game_server entity is not in the lobby, it will fail.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* ServerEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerEntity;
 };
 
 /**
@@ -484,13 +484,13 @@ struct PLAYFAB_API FMultiplayerRemoveMemberFromLobbyRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The id of the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         FString LobbyId;
     /** The member entity to be removed from the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* MemberEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MemberEntity;
     /** If true, removed member can never rejoin this lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         bool PreventRejoin = false;
@@ -504,10 +504,10 @@ struct PLAYFAB_API FMultiplayerSubscribeToLobbyResourceRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity performing the subscription. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* EntityKey = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EntityKey;
     /** Opaque string, given to a client upon creating a connection with PubSub. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         FString PubSubConnectionHandle;
@@ -547,10 +547,10 @@ struct PLAYFAB_API FMultiplayerUnsubscribeFromLobbyResourceRequest : public FPla
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity which performed the subscription. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* EntityKey = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EntityKey;
     /** Opaque string, given to a client upon creating a connection with PubSub. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         FString PubSubConnectionHandle;
@@ -582,7 +582,7 @@ public:
         EAccessPolicy AccessPolicy = StaticCast<EAccessPolicy>(0);
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The private key-value pairs which are visible to all entities in the lobby. Optional. Sets or updates key-value pairs on
      * the lobby. Only the current lobby owner can set lobby data. Keys may be an arbitrary string of at most 30 characters.
@@ -590,7 +590,7 @@ public:
      * to 30 key-value pairs stored here. Keys are case sensitive.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* LobbyData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> LobbyData;
     /** The keys to delete from the lobby LobbyData. Optional. Behaves similar to searchDataToDelete, but applies to lobbyData. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         FString LobbyDataToDelete;
@@ -612,7 +612,7 @@ public:
      * bytes. Keys are case sensitive. Servers cannot specifiy this.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* MemberData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MemberData;
     /**
      * The keys to delete from the lobby MemberData. Optional. Deletes key-value pairs on the caller's member data. All the
      * specified keys will be removed from the caller's member data. Keys that do not exist are a no-op. If the key to delete
@@ -622,7 +622,7 @@ public:
         FString MemberDataToDelete;
     /** The member entity whose data is being modified. Servers cannot specify this. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* MemberEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MemberEntity;
     /**
      * A setting indicating whether the lobby is locked. May be 'Unlocked' or 'Locked'. When Locked new members are not allowed
      * to join. Defaults to 'Unlocked' on creation. Can only be changed by the lobby owner.
@@ -641,7 +641,7 @@ public:
      * server-owned (must be 'Server') - Any server can set ownership. The useConnections property must be true.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* Owner = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Owner;
     /**
      * A setting that controls whether only the lobby owner can send invites to join the lobby. When true, only the lobby owner
      * can send invites. When false or not specified, any member can send invites. Will not modify current configuration if not
@@ -658,7 +658,7 @@ public:
      * all searchData values may not exceed 1024 bytes.Keys are case sensitive.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* SearchData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> SearchData;
     /**
      * The keys to delete from the lobby SearchData. Optional. Deletes key-value pairs on the lobby. Only the current lobby
      * owner can delete search data. All the specified keys will be removed from the search data. Keys that do not exist in the
@@ -679,7 +679,7 @@ struct PLAYFAB_API FMultiplayerUpdateLobbyAsServerRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The id of the lobby. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
         FString LobbyId;
@@ -690,7 +690,7 @@ public:
      * Values are not individually limited. There can be up to 30 key-value pairs stored here. Keys are case sensitive.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* ServerData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerData;
     /**
      * The keys to delete from the lobby serverData. Optional. Optional. Deletes key-value pairs on the lobby. Only the current
      * joined lobby server can delete serverData. All the specified keys will be removed from the serverData. Keys that do not
@@ -704,7 +704,7 @@ public:
      * server). When changing the server the previous server will automatically be unsubscribed.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Lobby Models")
-        UPlayFabJsonObject* ServerEntity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerEntity;
 };
 
 
@@ -725,10 +725,10 @@ struct PLAYFAB_API FMultiplayerCancelAllMatchmakingTicketsForPlayerRequest : pub
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity key of the player whose tickets should be canceled. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The name of the queue from which a player's tickets should be canceled. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
@@ -753,10 +753,10 @@ struct PLAYFAB_API FMultiplayerCancelAllServerBackfillTicketsForPlayerRequest : 
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity key of the player whose backfill tickets should be canceled. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The name of the queue from which a player's backfill tickets should be canceled. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
@@ -787,7 +787,7 @@ struct PLAYFAB_API FMultiplayerCancelMatchmakingTicketRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the queue the ticket is in. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
@@ -818,7 +818,7 @@ struct PLAYFAB_API FMultiplayerCancelServerBackfillTicketRequest : public FPlayF
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the queue the ticket is in. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
@@ -842,16 +842,16 @@ struct PLAYFAB_API FMultiplayerCreateMatchmakingTicketRequest : public FPlayFabR
 public:
     /** The User who created this ticket. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* Creator = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Creator;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** How long to attempt matching this ticket in seconds. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         int32 GiveUpAfterSeconds = 0;
     /** A list of Entity Keys of other users to match with. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        TArray<UPlayFabJsonObject*> MembersToMatchWith;
+        TArray<TObjectPtr<UPlayFabJsonObject>> MembersToMatchWith;
     /** The Id of a match queue. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
@@ -875,19 +875,19 @@ struct PLAYFAB_API FMultiplayerCreateServerBackfillTicketRequest : public FPlayF
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** How long to attempt matching this ticket in seconds. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         int32 GiveUpAfterSeconds = 0;
     /** The users who will be part of this ticket, along with their team assignments. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        TArray<UPlayFabJsonObject*> Members;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Members;
     /** The Id of a match queue. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
     /** The details of the server the members are connected to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* ServerDetails = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerDetails;
 };
 
 USTRUCT(BlueprintType)
@@ -908,13 +908,13 @@ struct PLAYFAB_API FMultiplayerCreateServerMatchmakingTicketRequest : public FPl
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** How long to attempt matching this ticket in seconds. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         int32 GiveUpAfterSeconds = 0;
     /** The users who will be part of this ticket. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        TArray<UPlayFabJsonObject*> Members;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Members;
     /** The Id of a match queue. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
@@ -932,7 +932,7 @@ struct PLAYFAB_API FMultiplayerGetMatchRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Determines whether the matchmaking attributes will be returned as an escaped JSON string or as an un-escaped JSON
      * object.
@@ -963,7 +963,7 @@ public:
         FString MatchId;
     /** A list of Users that are matched together, along with their team assignments. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        TArray<UPlayFabJsonObject*> Members;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Members;
     /**
      * A list of regions that the match could be played in sorted by preference. This value is only set if the queue has a
      * region selection rule.
@@ -972,7 +972,7 @@ public:
         FString RegionPreferences;
     /** The details of the server that the match has been allocated to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* ServerDetails = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerDetails;
 };
 
 /**
@@ -986,7 +986,7 @@ struct PLAYFAB_API FMultiplayerGetMatchmakingTicketRequest : public FPlayFabRequ
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Determines whether the matchmaking attributes will be returned as an escaped JSON string or as an un-escaped JSON
      * object.
@@ -1020,7 +1020,7 @@ public:
         FString Created;
     /** The Creator's entity key. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* Creator = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Creator;
     /** How long to attempt matching this ticket in seconds. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         int32 GiveUpAfterSeconds = 0;
@@ -1029,10 +1029,10 @@ public:
         FString MatchId;
     /** A list of Users that have joined this ticket. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        TArray<UPlayFabJsonObject*> Members;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Members;
     /** A list of PlayFab Ids of Users to match with. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        TArray<UPlayFabJsonObject*> MembersToMatchWith;
+        TArray<TObjectPtr<UPlayFabJsonObject>> MembersToMatchWith;
     /** The Id of a match queue. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
@@ -1061,7 +1061,7 @@ struct PLAYFAB_API FMultiplayerGetQueueStatisticsRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the queue. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
@@ -1077,7 +1077,7 @@ public:
         int32 NumberOfPlayersMatching = 0;
     /** Statistics representing the time (in seconds) it takes for tickets to find a match. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* TimeToMatchStatisticsInSeconds = nullptr;
+        TObjectPtr<UPlayFabJsonObject> TimeToMatchStatisticsInSeconds;
 };
 
 /**
@@ -1091,7 +1091,7 @@ struct PLAYFAB_API FMultiplayerGetServerBackfillTicketRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Determines whether the matchmaking attributes will be returned as an escaped JSON string or as an un-escaped JSON
      * object.
@@ -1125,13 +1125,13 @@ public:
         FString MatchId;
     /** A list of Users that are part of this ticket, along with their team assignments. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        TArray<UPlayFabJsonObject*> Members;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Members;
     /** The Id of a match queue. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
     /** The details of the server the members are connected to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* ServerDetails = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerDetails;
     /** The current ticket status. Possible values are: WaitingForMatch, Canceled and Matched. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString Status;
@@ -1153,10 +1153,10 @@ struct PLAYFAB_API FMultiplayerJoinMatchmakingTicketRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The User who wants to join the ticket. Their Id must be listed in PlayFabIdsToMatchWith. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* Member = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Member;
     /** The name of the queue to join. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
@@ -1183,10 +1183,10 @@ struct PLAYFAB_API FMultiplayerListMatchmakingTicketsForPlayerRequest : public F
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity key for which to find the ticket Ids. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The name of the queue to find a match for. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
@@ -1210,10 +1210,10 @@ struct PLAYFAB_API FMultiplayerListServerBackfillTicketsForPlayerRequest : publi
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity key for which to find the ticket Ids. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The name of the queue the tickets are in. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | Matchmaking Models")
         FString QueueName;
@@ -1252,7 +1252,7 @@ public:
         FString AliasName;
     /** Array of build selection criteria. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> BuildSelectionCriteria;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BuildSelectionCriteria;
 };
 
 /** Creates a multiplayer server build alias and returns the created alias. */
@@ -1266,10 +1266,10 @@ public:
         FString AliasName;
     /** Array of build selection criteria. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> BuildSelectionCriteria;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BuildSelectionCriteria;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 /** Creates a multiplayer server build with a custom container and returns information about the build creation request. */
@@ -1292,52 +1292,52 @@ public:
         EContainerFlavor ContainerFlavor = StaticCast<EContainerFlavor>(0);
     /** The container reference, consisting of the image name and tag. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* ContainerImageReference = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ContainerImageReference;
     /** The container command to run when the multiplayer server has been allocated, including any arguments. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString ContainerRunCommand;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The list of game assets related to the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameAssetReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameAssetReferences;
     /** The game certificates for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameCertificateReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameCertificateReferences;
     /** The game secrets for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameSecretReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameSecretReferences;
     /** The Linux instrumentation configuration for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* LinuxInstrumentationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> LinuxInstrumentationConfiguration;
     /**
      * Metadata to tag the build. The keys are case insensitive. The build metadata is made available to the server through
      * Game Server SDK (GSDK).Constraints: Maximum number of keys: 30, Maximum key length: 50, Maximum value length: 100
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* Metadata = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Metadata;
     /** The configuration for the monitoring application on the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* MonitoringApplicationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MonitoringApplicationConfiguration;
     /** The number of multiplayer servers to host on a single VM. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 MultiplayerServerCountPerVm = 0;
     /** The ports to map the build on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> Ports;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Ports;
     /** The region configurations for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> RegionConfigurations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> RegionConfigurations;
     /** The resource constraints to apply to each server on the VM (EXPERIMENTAL API) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* ServerResourceConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerResourceConstraints;
     /** The VM size to create the build on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         EAzureVmSize VmSize = StaticCast<EAzureVmSize>(0);
     /** The configuration for the VmStartupScript for the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* VmStartupScriptConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VmStartupScriptConfiguration;
 };
 
 USTRUCT(BlueprintType)
@@ -1368,25 +1368,25 @@ public:
         FString CreationTime;
     /** The custom game container image reference information. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomGameContainerImage = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomGameContainerImage;
     /** The game assets for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameAssetReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameAssetReferences;
     /** The game certificates for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameCertificateReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameCertificateReferences;
     /** The game secrets for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameSecretReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameSecretReferences;
     /** The Linux instrumentation configuration for this build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* LinuxInstrumentationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> LinuxInstrumentationConfiguration;
     /** The metadata of the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* Metadata = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Metadata;
     /** The configuration for the monitoring application for the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* MonitoringApplicationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MonitoringApplicationConfiguration;
     /** The number of multiplayer servers to host on a single VM of the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 MultiplayerServerCountPerVm = 0;
@@ -1395,13 +1395,13 @@ public:
         FString OsPlatform;
     /** The ports the build is mapped on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> Ports;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Ports;
     /** The region configuration for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> RegionConfigurations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> RegionConfigurations;
     /** The resource constraints to apply to each server on the VM (EXPERIMENTAL API) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* ServerResourceConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerResourceConstraints;
     /** The type of game server being hosted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString ServerType;
@@ -1416,7 +1416,7 @@ public:
         EAzureVmSize VmSize = StaticCast<EAzureVmSize>(0);
     /** The configuration for the VmStartupScript feature for the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* VmStartupScriptConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VmStartupScriptConfiguration;
 };
 
 /** Creates a multiplayer server build with a managed container and returns information about the build creation request. */
@@ -1439,16 +1439,16 @@ public:
         EContainerFlavor ContainerFlavor = StaticCast<EContainerFlavor>(0);
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The list of game assets related to the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameAssetReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameAssetReferences;
     /** The game certificates for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameCertificateReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameCertificateReferences;
     /** The game secrets for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameSecretReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameSecretReferences;
     /**
      * The directory containing the game executable. This would be the start path of the game assets that contain the main game
      * server executable. If not provided, a best effort will be made to extract it from the start game command.
@@ -1457,28 +1457,28 @@ public:
         FString GameWorkingDirectory;
     /** The instrumentation configuration for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* InstrumentationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InstrumentationConfiguration;
     /**
      * Metadata to tag the build. The keys are case insensitive. The build metadata is made available to the server through
      * Game Server SDK (GSDK).Constraints: Maximum number of keys: 30, Maximum key length: 50, Maximum value length: 100
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* Metadata = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Metadata;
     /** The configuration for the monitoring application on the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* MonitoringApplicationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MonitoringApplicationConfiguration;
     /** The number of multiplayer servers to host on a single VM. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 MultiplayerServerCountPerVm = 0;
     /** The ports to map the build on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> Ports;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Ports;
     /** The region configurations for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> RegionConfigurations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> RegionConfigurations;
     /** The resource constraints to apply to each server on the VM (EXPERIMENTAL API) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* ServerResourceConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerResourceConstraints;
     /** The command to run when the multiplayer server is started, including any arguments. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString StartMultiplayerServerCommand;
@@ -1487,10 +1487,10 @@ public:
         EAzureVmSize VmSize = StaticCast<EAzureVmSize>(0);
     /** The configuration for the VmStartupScript for the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* VmStartupScriptConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VmStartupScriptConfiguration;
     /** The crash dump configuration for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* WindowsCrashDumpConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> WindowsCrashDumpConfiguration;
 };
 
 USTRUCT(BlueprintType)
@@ -1518,13 +1518,13 @@ public:
         FString CreationTime;
     /** The game assets for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameAssetReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameAssetReferences;
     /** The game certificates for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameCertificateReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameCertificateReferences;
     /** The game secrets for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameSecretReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameSecretReferences;
     /**
      * The directory containing the game executable. This would be the start path of the game assets that contain the main game
      * server executable. If not provided, a best effort will be made to extract it from the start game command.
@@ -1533,13 +1533,13 @@ public:
         FString GameWorkingDirectory;
     /** The instrumentation configuration for this build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* InstrumentationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InstrumentationConfiguration;
     /** The metadata of the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* Metadata = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Metadata;
     /** The configuration for the monitoring application for the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* MonitoringApplicationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MonitoringApplicationConfiguration;
     /** The number of multiplayer servers to host on a single VM of the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 MultiplayerServerCountPerVm = 0;
@@ -1548,13 +1548,13 @@ public:
         FString OsPlatform;
     /** The ports the build is mapped on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> Ports;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Ports;
     /** The region configuration for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> RegionConfigurations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> RegionConfigurations;
     /** The resource constraints to apply to each server on the VM (EXPERIMENTAL API) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* ServerResourceConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerResourceConstraints;
     /** The type of game server being hosted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString ServerType;
@@ -1572,7 +1572,7 @@ public:
         EAzureVmSize VmSize = StaticCast<EAzureVmSize>(0);
     /** The configuration for the VmStartupScript feature for the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* VmStartupScriptConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VmStartupScriptConfiguration;
 };
 
 /**
@@ -1595,16 +1595,16 @@ public:
         FString BuildName;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The list of game assets related to the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameAssetReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameAssetReferences;
     /** The game certificates for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameCertificateReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameCertificateReferences;
     /** The game secrets for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameSecretReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameSecretReferences;
     /**
      * The working directory for the game process. If this is not provided, the working directory will be set based on the
      * mount path of the game server executable.
@@ -1613,7 +1613,7 @@ public:
         FString GameWorkingDirectory;
     /** The instrumentation configuration for the Build. Used only if it is a Windows Build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* InstrumentationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InstrumentationConfiguration;
     /**
      * Indicates whether this build will be created using the OS Preview versionPreview OS is recommended for dev builds to
      * detect any breaking changes before they are released to retail. Retail builds should set this value to false.
@@ -1622,16 +1622,16 @@ public:
         bool IsOSPreview = false;
     /** The Linux instrumentation configuration for the Build. Used only if it is a Linux Build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* LinuxInstrumentationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> LinuxInstrumentationConfiguration;
     /**
      * Metadata to tag the build. The keys are case insensitive. The build metadata is made available to the server through
      * Game Server SDK (GSDK).Constraints: Maximum number of keys: 30, Maximum key length: 50, Maximum value length: 100
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* Metadata = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Metadata;
     /** The configuration for the monitoring application on the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* MonitoringApplicationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MonitoringApplicationConfiguration;
     /** The number of multiplayer servers to host on a single VM. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 MultiplayerServerCountPerVm = 0;
@@ -1640,10 +1640,10 @@ public:
         FString OsPlatform;
     /** The ports to map the build on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> Ports;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Ports;
     /** The region configurations for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> RegionConfigurations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> RegionConfigurations;
     /**
      * The command to run when the multiplayer server is started, including any arguments. The path to any executable should be
      * relative to the root asset folder when unzipped.
@@ -1655,7 +1655,7 @@ public:
         EAzureVmSize VmSize = StaticCast<EAzureVmSize>(0);
     /** The configuration for the VmStartupScript for the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* VmStartupScriptConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VmStartupScriptConfiguration;
 };
 
 USTRUCT(BlueprintType)
@@ -1683,13 +1683,13 @@ public:
         FString CreationTime;
     /** The game assets for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameAssetReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameAssetReferences;
     /** The game certificates for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameCertificateReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameCertificateReferences;
     /** The game secrets for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameSecretReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameSecretReferences;
     /**
      * The working directory for the game process. If this is not provided, the working directory will be set based on the
      * mount path of the game server executable.
@@ -1698,7 +1698,7 @@ public:
         FString GameWorkingDirectory;
     /** The instrumentation configuration for this build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* InstrumentationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InstrumentationConfiguration;
     /**
      * Indicates whether this build will be created using the OS Preview versionPreview OS is recommended for dev builds to
      * detect any breaking changes before they are released to retail. Retail builds should set this value to false.
@@ -1707,13 +1707,13 @@ public:
         bool IsOSPreview = false;
     /** The Linux instrumentation configuration for this build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* LinuxInstrumentationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> LinuxInstrumentationConfiguration;
     /** The metadata of the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* Metadata = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Metadata;
     /** The configuration for the monitoring application for the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* MonitoringApplicationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MonitoringApplicationConfiguration;
     /** The number of multiplayer servers to host on a single VM of the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 MultiplayerServerCountPerVm = 0;
@@ -1722,10 +1722,10 @@ public:
         FString OsPlatform;
     /** The ports the build is mapped on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> Ports;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Ports;
     /** The region configuration for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> RegionConfigurations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> RegionConfigurations;
     /** The type of game server being hosted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString ServerType;
@@ -1746,7 +1746,7 @@ public:
         EAzureVmSize VmSize = StaticCast<EAzureVmSize>(0);
     /** The configuration for the VmStartupScript feature for the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* VmStartupScriptConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VmStartupScriptConfiguration;
 };
 
 /**
@@ -1763,7 +1763,7 @@ public:
         FString BuildId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The expiration time for the remote user created. Defaults to expiring in one day if not specified. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString ExpirationTime;
@@ -1805,13 +1805,13 @@ public:
         FString ChangeDescription;
     /** Changes to make to the titles cores quota. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> Changes;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Changes;
     /** Email to be contacted by our team about this request. Only required when a request is not approved. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString ContactEmail;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Additional information about this request that our team can use to better understand the requirements. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString Notes;
@@ -1841,7 +1841,7 @@ struct PLAYFAB_API FMultiplayerDeleteAssetRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The filename of the asset to delete. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString FileName;
@@ -1865,7 +1865,7 @@ public:
         FString BuildId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 /** Deletes a multiplayer server build alias. */
@@ -1879,7 +1879,7 @@ public:
         FString AliasId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 /** Removes a multiplayer server build's region. */
@@ -1893,7 +1893,7 @@ public:
         FString BuildId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The build region to delete. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString Region;
@@ -1907,7 +1907,7 @@ struct PLAYFAB_API FMultiplayerDeleteCertificateRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the certificate. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString Name;
@@ -1924,7 +1924,7 @@ struct PLAYFAB_API FMultiplayerDeleteContainerImageRequest : public FPlayFabRequ
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The container image repository we want to delete. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString ImageName;
@@ -1944,7 +1944,7 @@ public:
         FString BuildId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The region of the multiplayer server where the remote user is to delete. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString Region;
@@ -1964,7 +1964,7 @@ struct PLAYFAB_API FMultiplayerDeleteSecretRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the secret. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString Name;
@@ -1982,7 +1982,7 @@ struct PLAYFAB_API FMultiplayerEnableMultiplayerServersForTitleRequest : public 
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -2003,7 +2003,7 @@ struct PLAYFAB_API FMultiplayerGetAssetDownloadUrlRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The asset's file name to get the download URL for. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString FileName;
@@ -2030,7 +2030,7 @@ struct PLAYFAB_API FMultiplayerGetAssetUploadUrlRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The asset's file name to get the upload URL for. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString FileName;
@@ -2060,7 +2060,7 @@ public:
         FString BuildId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -2097,22 +2097,22 @@ public:
         FString CreationTime;
     /** The custom game container image for a custom build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomGameContainerImage = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomGameContainerImage;
     /** The game assets for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameAssetReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameAssetReferences;
     /** The game certificates for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> GameCertificateReferences;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GameCertificateReferences;
     /** The instrumentation configuration of the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* InstrumentationConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InstrumentationConfiguration;
     /**
      * Metadata of the build. The keys are case insensitive. The build metadata is made available to the server through Game
      * Server SDK (GSDK).
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* Metadata = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Metadata;
     /** The number of multiplayer servers to hosted on a single VM of the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 MultiplayerServerCountPerVm = 0;
@@ -2121,13 +2121,13 @@ public:
         FString OsPlatform;
     /** The ports the build is mapped on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> Ports;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Ports;
     /** The region configuration for the build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> RegionConfigurations;
+        TArray<TObjectPtr<UPlayFabJsonObject>> RegionConfigurations;
     /** The resource constraints to apply to each server on the VM. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* ServerResourceConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ServerResourceConstraints;
     /** The type of game server being hosted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString ServerType;
@@ -2142,7 +2142,7 @@ public:
         EAzureVmSize VmSize = StaticCast<EAzureVmSize>(0);
     /** The configuration for the VmStartupScript feature for the build */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* VmStartupScriptConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VmStartupScriptConfiguration;
 };
 
 /** Returns the details about a multiplayer server build alias. */
@@ -2156,7 +2156,7 @@ public:
         FString AliasId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 /**
@@ -2170,7 +2170,7 @@ struct PLAYFAB_API FMultiplayerGetContainerRegistryCredentialsRequest : public F
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -2197,7 +2197,7 @@ struct PLAYFAB_API FMultiplayerGetMultiplayerServerDetailsRequest : public FPlay
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The title generated guid string session ID of the multiplayer server to get details for. This is to keep track of
      * multiplayer server sessions.
@@ -2216,7 +2216,7 @@ public:
         FString BuildId;
     /** The connected players in the multiplayer server. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> ConnectedPlayers;
+        TArray<TObjectPtr<UPlayFabJsonObject>> ConnectedPlayers;
     /** The fully qualified domain name of the virtual machine that is hosting this multiplayer server. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString FQDN;
@@ -2228,10 +2228,10 @@ public:
         FString LastStateTransitionTime;
     /** The ports the multiplayer server uses. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> Ports;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Ports;
     /** The list of public Ipv4 addresses associated with the server. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> PublicIPV4Addresses;
+        TArray<TObjectPtr<UPlayFabJsonObject>> PublicIPV4Addresses;
     /** The region the multiplayer server is located in. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString Region;
@@ -2260,7 +2260,7 @@ struct PLAYFAB_API FMultiplayerGetMultiplayerServerLogsRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The server ID of multiplayer server to get logs for. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString ServerId;
@@ -2287,7 +2287,7 @@ struct PLAYFAB_API FMultiplayerGetMultiplayerSessionLogsBySessionIdRequest : pub
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The server ID of multiplayer server to get logs for. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString SessionId;
@@ -2304,7 +2304,7 @@ public:
         FString BuildId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The region of the multiplayer server to get remote login information for. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString Region;
@@ -2337,7 +2337,7 @@ struct PLAYFAB_API FMultiplayerGetTitleEnabledForMultiplayerServersStatusRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -2358,7 +2358,7 @@ struct PLAYFAB_API FMultiplayerGetTitleMultiplayerServersQuotaChangeRequest : pu
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Id of the change request to get. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString RequestId;
@@ -2371,7 +2371,7 @@ struct PLAYFAB_API FMultiplayerGetTitleMultiplayerServersQuotaChangeResponse : p
 public:
     /** The change request for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* Change = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Change;
 };
 
 /** Gets the quotas for a title in relation to multiplayer servers. */
@@ -2382,7 +2382,7 @@ struct PLAYFAB_API FMultiplayerGetTitleMultiplayerServersQuotasRequest : public 
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -2392,7 +2392,7 @@ struct PLAYFAB_API FMultiplayerGetTitleMultiplayerServersQuotasResponse : public
 public:
     /** The various quotas for multiplayer servers for the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* Quotas = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Quotas;
 };
 
 /** Returns a list of multiplayer servers for a build in a specific region. */
@@ -2406,7 +2406,7 @@ public:
         FString BuildId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The page size for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2425,7 +2425,7 @@ struct PLAYFAB_API FMultiplayerListMultiplayerServersResponse : public FPlayFabR
 public:
     /** The list of multiplayer server summary details. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> MultiplayerServerSummaries;
+        TArray<TObjectPtr<UPlayFabJsonObject>> MultiplayerServerSummaries;
     /** The page size on the response. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2442,7 +2442,7 @@ struct PLAYFAB_API FMultiplayerListAssetSummariesRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The page size for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2458,7 +2458,7 @@ struct PLAYFAB_API FMultiplayerListAssetSummariesResponse : public FPlayFabResul
 public:
     /** The list of asset summaries. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> AssetSummaries;
+        TArray<TObjectPtr<UPlayFabJsonObject>> AssetSummaries;
     /** The page size on the response. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2475,7 +2475,7 @@ struct PLAYFAB_API FMultiplayerListBuildAliasesRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The page size for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2491,7 +2491,7 @@ struct PLAYFAB_API FMultiplayerListBuildAliasesResponse : public FPlayFabResultC
 public:
     /** The list of build aliases for the title */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> BuildAliases;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BuildAliases;
     /** The page size on the response. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2508,7 +2508,7 @@ struct PLAYFAB_API FMultiplayerListBuildSummariesRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The page size for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2524,7 +2524,7 @@ struct PLAYFAB_API FMultiplayerListBuildSummariesResponse : public FPlayFabResul
 public:
     /** The list of build summaries for a title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> BuildSummaries;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BuildSummaries;
     /** The page size on the response. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2541,7 +2541,7 @@ struct PLAYFAB_API FMultiplayerListCertificateSummariesRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The page size for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2557,7 +2557,7 @@ struct PLAYFAB_API FMultiplayerListCertificateSummariesResponse : public FPlayFa
 public:
     /** The list of game certificates. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> CertificateSummaries;
+        TArray<TObjectPtr<UPlayFabJsonObject>> CertificateSummaries;
     /** The page size on the response. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2574,7 +2574,7 @@ struct PLAYFAB_API FMultiplayerListContainerImagesRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The page size for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2607,7 +2607,7 @@ struct PLAYFAB_API FMultiplayerListContainerImageTagsRequest : public FPlayFabRe
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The container images we want to list tags for. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString ImageName;
@@ -2643,7 +2643,7 @@ struct PLAYFAB_API FMultiplayerListPartyQosServersRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -2656,7 +2656,7 @@ public:
         int32 PageSize = 0;
     /** The list of QoS servers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> QosServers;
+        TArray<TObjectPtr<UPlayFabJsonObject>> QosServers;
     /** The skip token for the paged response. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString SkipToken;
@@ -2670,7 +2670,7 @@ struct PLAYFAB_API FMultiplayerListQosServersForTitleRequest : public FPlayFabRe
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Indicates that the response should contain Qos servers for all regions, including those where there are no builds
      * deployed for the title.
@@ -2692,7 +2692,7 @@ public:
         int32 PageSize = 0;
     /** The list of QoS servers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> QosServers;
+        TArray<TObjectPtr<UPlayFabJsonObject>> QosServers;
     /** The skip token for the paged response. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString SkipToken;
@@ -2706,7 +2706,7 @@ struct PLAYFAB_API FMultiplayerListSecretSummariesRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The page size for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2725,7 +2725,7 @@ public:
         int32 PageSize = 0;
     /** The list of game secret. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> SecretSummaries;
+        TArray<TObjectPtr<UPlayFabJsonObject>> SecretSummaries;
     /** The skip token for the paged response. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString SkipToken;
@@ -2739,7 +2739,7 @@ struct PLAYFAB_API FMultiplayerListTitleMultiplayerServersQuotaChangesRequest : 
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -2749,7 +2749,7 @@ struct PLAYFAB_API FMultiplayerListTitleMultiplayerServersQuotaChangesResponse :
 public:
     /** All change requests for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> Changes;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Changes;
 };
 
 /** Returns a list of virtual machines for a title. */
@@ -2763,7 +2763,7 @@ public:
         FString BuildId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The page size for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         int32 PageSize = 0;
@@ -2788,7 +2788,7 @@ public:
         FString SkipToken;
     /** The list of virtual machine summaries. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> VirtualMachines;
+        TArray<TObjectPtr<UPlayFabJsonObject>> VirtualMachines;
 };
 
 /** Requests a multiplayer server session from a particular build in any of the given preferred regions. */
@@ -2799,13 +2799,13 @@ struct PLAYFAB_API FMultiplayerRequestMultiplayerServerRequest : public FPlayFab
 public:
     /** The identifiers of the build alias to use for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* BuildAliasParams = nullptr;
+        TObjectPtr<UPlayFabJsonObject> BuildAliasParams;
     /** The guid string build ID of the multiplayer server to request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString BuildId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Initial list of players (potentially matchmade) allowed to connect to the game. This list is passed to the game server
      * when requested (via GSDK) and can be used to validate players connecting to it.
@@ -2839,7 +2839,7 @@ public:
         FString BuildId;
     /** The connected players in the multiplayer server. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> ConnectedPlayers;
+        TArray<TObjectPtr<UPlayFabJsonObject>> ConnectedPlayers;
     /** The fully qualified domain name of the virtual machine that is hosting this multiplayer server. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString FQDN;
@@ -2851,10 +2851,10 @@ public:
         FString LastStateTransitionTime;
     /** The ports the multiplayer server uses. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> Ports;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Ports;
     /** The list of public Ipv4 addresses associated with the server. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> PublicIPV4Addresses;
+        TArray<TObjectPtr<UPlayFabJsonObject>> PublicIPV4Addresses;
     /** The region the multiplayer server is located in. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString Region;
@@ -2883,10 +2883,10 @@ struct PLAYFAB_API FMultiplayerRequestPartyServiceRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The network configuration for this request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* NetworkConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> NetworkConfiguration;
     /** A guid string party ID created track the party session over its life. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString PartyId;
@@ -2931,7 +2931,7 @@ struct PLAYFAB_API FMultiplayerRolloverContainerRegistryCredentialsRequest : pub
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -2962,7 +2962,7 @@ struct PLAYFAB_API FMultiplayerShutdownMultiplayerServerRequest : public FPlayFa
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** A guid string session ID of the multiplayer server to shut down. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString SessionId;
@@ -2979,7 +2979,7 @@ struct PLAYFAB_API FMultiplayerUntagContainerImageRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The container image which tag we want to remove. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         FString ImageName;
@@ -3002,10 +3002,10 @@ public:
         FString AliasName;
     /** Array of build selection criteria. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> BuildSelectionCriteria;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BuildSelectionCriteria;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 /** Updates a multiplayer server build's name. */
@@ -3022,7 +3022,7 @@ public:
         FString BuildName;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 /** Updates a multiplayer server build's region. */
@@ -3036,10 +3036,10 @@ public:
         FString BuildId;
     /** The updated region configuration that should be applied to the specified build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* BuildRegion = nullptr;
+        TObjectPtr<UPlayFabJsonObject> BuildRegion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 /** Updates a multiplayer server build's regions. */
@@ -3053,10 +3053,10 @@ public:
         FString BuildId;
     /** The updated region configuration that should be applied to the specified build. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        TArray<UPlayFabJsonObject*> BuildRegions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BuildRegions;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 /** Uploads a multiplayer server game certificate. */
@@ -3067,13 +3067,13 @@ struct PLAYFAB_API FMultiplayerUploadCertificateRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Forces the certificate renewal if the certificate already exists. Default is false */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         bool ForceUpdate = false;
     /** The game certificate to upload. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* GameCertificate = nullptr;
+        TObjectPtr<UPlayFabJsonObject> GameCertificate;
 };
 
 /** Uploads a multiplayer server game secret. */
@@ -3084,13 +3084,13 @@ struct PLAYFAB_API FMultiplayerUploadSecretRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Forces the secret renewal if the secret already exists. Default is false */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
         bool ForceUpdate = false;
     /** The game secret to add. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Multiplayer | MultiplayerServer Models")
-        UPlayFabJsonObject* GameSecret = nullptr;
+        TObjectPtr<UPlayFabJsonObject> GameSecret;
 };
 
 

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabProfilesAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabProfilesAPI.h
@@ -208,7 +208,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -216,11 +216,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabProfilesModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabProfilesModels.h
@@ -41,10 +41,10 @@ struct PLAYFAB_API FProfilesGetGlobalPolicyRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
 };
 
 USTRUCT(BlueprintType)
@@ -54,7 +54,7 @@ struct PLAYFAB_API FProfilesGetGlobalPolicyResponse : public FPlayFabResultCommo
 public:
     /** The permissions that govern access to all entities under this title or namespace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        TArray<UPlayFabJsonObject*> Permissions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Permissions;
 };
 
 /**
@@ -71,7 +71,7 @@ struct PLAYFAB_API FProfilesGetEntityProfileRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Determines whether the objects will be returned as an escaped JSON string or as a un-escaped JSON object. Default is
      * JSON string.
@@ -80,7 +80,7 @@ public:
         bool DataAsObject = false;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Determines whether the entity statistics will be returned in the entity profile. Default is false. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
         bool IncludeStatistics = false;
@@ -93,7 +93,7 @@ struct PLAYFAB_API FProfilesGetEntityProfileResponse : public FPlayFabResultComm
 public:
     /** Entity profile */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* Profile = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Profile;
 };
 
 /**
@@ -107,7 +107,7 @@ struct PLAYFAB_API FProfilesGetEntityProfilesRequest : public FPlayFabRequestCom
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Determines whether the objects will be returned as an escaped JSON string or as a un-escaped JSON object. Default is
      * JSON string.
@@ -116,7 +116,7 @@ public:
         bool DataAsObject = false;
     /** Entity keys of the profiles to load. Must be between 1 and 25 */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        TArray<UPlayFabJsonObject*> Entities;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Entities;
     /** Determines whether the entity statistics will be returned in the entity profile. Default is false. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
         bool IncludeStatistics = false;
@@ -129,7 +129,7 @@ struct PLAYFAB_API FProfilesGetEntityProfilesResponse : public FPlayFabResultCom
 public:
     /** Entity profiles */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        TArray<UPlayFabJsonObject*> Profiles;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Profiles;
 };
 
 /** Given a master player account id (PlayFab ID), returns all title player accounts associated with it. */
@@ -140,7 +140,7 @@ struct PLAYFAB_API FProfilesGetTitlePlayersFromMasterPlayerAccountIdsRequest : p
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Master player account ids. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
         FString MasterPlayerAccountIds;
@@ -156,7 +156,7 @@ public:
         FString TitleId;
     /** Dictionary of master player ids mapped to title player entity keys and id pairs */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* TitlePlayerAccounts = nullptr;
+        TObjectPtr<UPlayFabJsonObject> TitlePlayerAccounts;
 };
 
 USTRUCT(BlueprintType)
@@ -169,7 +169,7 @@ public:
      * doesn't exist or doesn't play the requested title.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* TitlePlayerAccounts = nullptr;
+        TObjectPtr<UPlayFabJsonObject> TitlePlayerAccounts;
 };
 
 /** Given a collection of Xbox IDs (XUIDs), returns all title player accounts. */
@@ -180,7 +180,7 @@ struct PLAYFAB_API FProfilesGetTitlePlayersFromXboxLiveIDsRequest : public FPlay
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Xbox Sandbox the players had on their Xbox tokens. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
         FString Sandbox;
@@ -200,13 +200,13 @@ struct PLAYFAB_API FProfilesSetDisplayNameRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The new value to be set on Entity Profile's display name */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
         FString DisplayName;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The expected version of a profile to perform this update on */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
         int32 ExpectedVersion = 0;
@@ -236,10 +236,10 @@ struct PLAYFAB_API FProfilesSetGlobalPolicyRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The permissions that govern access to all entities under this title or namespace. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        TArray<UPlayFabJsonObject*> Permissions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Permissions;
 };
 
 USTRUCT(BlueprintType)
@@ -260,10 +260,10 @@ struct PLAYFAB_API FProfilesSetProfileLanguageRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The expected version of a profile to perform this update on */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
         int32 ExpectedVersion = 0;
@@ -296,13 +296,13 @@ struct PLAYFAB_API FProfilesSetEntityProfilePolicyRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity to perform this action on. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The statements to include in the access policy. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        TArray<UPlayFabJsonObject*> Statements;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statements;
 };
 
 USTRUCT(BlueprintType)
@@ -315,6 +315,6 @@ public:
      * profile, not global statements from titles and namespaces.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Profiles | Account Management Models")
-        TArray<UPlayFabJsonObject*> Permissions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Permissions;
 };
 

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabProgressionAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabProgressionAPI.h
@@ -422,7 +422,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -430,11 +430,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabProgressionModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabProgressionModels.h
@@ -40,10 +40,10 @@ public:
      * allowed.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        TArray<UPlayFabJsonObject*> Columns;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Columns;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The entity type being represented on the leaderboard. If it doesn't correspond to the PlayFab entity types, use
      * 'external' as the type.
@@ -52,7 +52,7 @@ public:
         FString EntityType;
     /** [In Preview]: The configuration for the events emitted by this leaderboard. If not specified, no events will be emitted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* EventEmissionConfig = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EventEmissionConfig;
     /** A name for the leaderboard, unique per title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString Name;
@@ -61,7 +61,7 @@ public:
         int32 SizeLimit = 0;
     /** The version reset configuration for the leaderboard definition. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* VersionConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VersionConfiguration;
 };
 
 USTRUCT(BlueprintType)
@@ -78,7 +78,7 @@ struct PLAYFAB_API FProgressionDeleteLeaderboardDefinitionRequest : public FPlay
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the leaderboard definition to delete. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString Name;
@@ -91,7 +91,7 @@ struct PLAYFAB_API FProgressionDeleteLeaderboardEntriesRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The unique Ids of the entries to delete from the leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString EntityIds;
@@ -108,7 +108,7 @@ struct PLAYFAB_API FProgressionGetEntityLeaderboardResponse : public FPlayFabRes
 public:
     /** Leaderboard columns describing the sort directions. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        TArray<UPlayFabJsonObject*> Columns;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Columns;
     /** The number of entries on the leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         int32 EntryCount = 0;
@@ -117,7 +117,7 @@ public:
         FString NextReset;
     /** Individual entity rankings in the leaderboard, in sorted order by rank. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        TArray<UPlayFabJsonObject*> Rankings;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Rankings;
     /** Version of the leaderboard being returned. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         int32 Version = 0;
@@ -130,10 +130,10 @@ struct PLAYFAB_API FProgressionGetFriendLeaderboardForEntityRequest : public FPl
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /**
      * Indicates which other platforms' friends should be included in the response. In HTTP, it is represented as a
      * comma-separated list of platforms.
@@ -159,7 +159,7 @@ struct PLAYFAB_API FProgressionGetEntityLeaderboardRequest : public FPlayFabRequ
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Name of the leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString LeaderboardName;
@@ -182,10 +182,10 @@ struct PLAYFAB_API FProgressionGetLeaderboardAroundEntityRequest : public FPlayF
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Name of the leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString LeaderboardName;
@@ -210,7 +210,7 @@ struct PLAYFAB_API FProgressionGetLeaderboardDefinitionRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the leaderboard to retrieve the definition for. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString Name;
@@ -223,7 +223,7 @@ struct PLAYFAB_API FProgressionGetLeaderboardDefinitionResponse : public FPlayFa
 public:
     /** Sort direction of the leaderboard columns, cannot be changed after creation. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        TArray<UPlayFabJsonObject*> Columns;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Columns;
     /** Created time, in UTC */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString Created;
@@ -235,7 +235,7 @@ public:
         FString EntityType;
     /** [In Preview]: The configuration for the events emitted by this leaderboard. If not specified, no events will be emitted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* EventEmissionConfig = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EventEmissionConfig;
     /** Last time, in UTC, leaderboard version was incremented. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString LastResetTime;
@@ -250,7 +250,7 @@ public:
         int32 Version = 0;
     /** The version reset configuration for the leaderboard definition. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* VersionConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VersionConfiguration;
 };
 
 /** Request a leaderboard limited to a collection of entities. */
@@ -261,7 +261,7 @@ struct PLAYFAB_API FProgressionGetLeaderboardForEntitiesRequest : public FPlayFa
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Collection of Entity IDs to include in the leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString EntityIds;
@@ -280,7 +280,7 @@ struct PLAYFAB_API FProgressionIncrementLeaderboardVersionRequest : public FPlay
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the leaderboard to increment the version for. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString Name;
@@ -303,7 +303,7 @@ struct PLAYFAB_API FProgressionListLeaderboardDefinitionsRequest : public FPlayF
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The page size for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         int32 PageSize = 0;
@@ -319,7 +319,7 @@ struct PLAYFAB_API FProgressionListLeaderboardDefinitionsResponse : public FPlay
 public:
     /** List of leaderboard definitions for the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        TArray<UPlayFabJsonObject*> LeaderboardDefinitions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> LeaderboardDefinitions;
     /** The page size on the response. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         int32 PageSize = 0;
@@ -335,7 +335,7 @@ struct PLAYFAB_API FProgressionUnlinkLeaderboardFromStatisticRequest : public FP
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the leaderboard definition to unlink. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString Name;
@@ -351,10 +351,10 @@ struct PLAYFAB_API FProgressionUpdateLeaderboardDefinitionRequest : public FPlay
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** [In Preview]: The configuration for the events emitted by this leaderboard. If not specified, no events will be emitted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* EventEmissionConfig = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EventEmissionConfig;
     /** The name of the leaderboard to update the definition for. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString Name;
@@ -363,7 +363,7 @@ public:
         int32 SizeLimit = 0;
     /** The version reset configuration for the leaderboard definition. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* VersionConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VersionConfiguration;
 };
 
 USTRUCT(BlueprintType)
@@ -373,10 +373,10 @@ struct PLAYFAB_API FProgressionUpdateLeaderboardEntriesRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entries to add or update on the leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
-        TArray<UPlayFabJsonObject*> Entries;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Entries;
     /** The name of the leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Leaderboards Models")
         FString LeaderboardName;
@@ -401,22 +401,22 @@ public:
         FString AggregationSources;
     /** The columns for the statistic defining the aggregation method for each column. A maximum of 5 columns are allowed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        TArray<UPlayFabJsonObject*> Columns;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Columns;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The entity type allowed to have score(s) for this statistic. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString EntityType;
     /** [In Preview]: Configurations for different Statistics events that can be emitted by the service. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* EventEmissionConfig = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EventEmissionConfig;
     /** Name of the statistic. Must be less than 150 characters. Restricted to a-Z, 0-9, '(', ')', '_', '-' and '.'. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString Name;
     /** The version reset configuration for the statistic definition. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* VersionConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VersionConfiguration;
 };
 
 USTRUCT(BlueprintType)
@@ -426,7 +426,7 @@ struct PLAYFAB_API FProgressionDeleteStatisticDefinitionRequest : public FPlayFa
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Name of the statistic to delete. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString Name;
@@ -439,13 +439,13 @@ struct PLAYFAB_API FProgressionDeleteStatisticsRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Collection of statistics to remove from this entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        TArray<UPlayFabJsonObject*> Statistics;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statistics;
 };
 
 USTRUCT(BlueprintType)
@@ -455,7 +455,7 @@ struct PLAYFAB_API FProgressionDeleteStatisticsResponse : public FPlayFabResultC
 public:
     /** The entity id and type. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
 };
 
 USTRUCT(BlueprintType)
@@ -465,7 +465,7 @@ struct PLAYFAB_API FProgressionGetStatisticDefinitionRequest : public FPlayFabRe
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Name of the statistic. Must be less than 150 characters. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString Name;
@@ -488,7 +488,7 @@ public:
         FString AggregationSources;
     /** The columns for the statistic defining the aggregation method for each column. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        TArray<UPlayFabJsonObject*> Columns;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Columns;
     /** Created time, in UTC */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString Created;
@@ -497,7 +497,7 @@ public:
         FString EntityType;
     /** [In Preview]: Configurations for different Statistics events that can be emitted by the service. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* EventEmissionConfig = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EventEmissionConfig;
     /** Last time, in UTC, statistic version was incremented. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString LastResetTime;
@@ -512,7 +512,7 @@ public:
         int32 Version = 0;
     /** The version reset configuration for the leaderboard definition. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* VersionConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VersionConfiguration;
 };
 
 USTRUCT(BlueprintType)
@@ -522,10 +522,10 @@ struct PLAYFAB_API FProgressionGetStatisticsRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** The list of statistics to return for the user. If set to null, the current version of all statistics are returned. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString StatisticNames;
@@ -538,13 +538,13 @@ struct PLAYFAB_API FProgressionGetStatisticsResponse : public FPlayFabResultComm
 public:
     /** A mapping of statistic name to the columns defined in the corresponding definition. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* ColumnDetails = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ColumnDetails;
     /** The entity id and type. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** List of statistics keyed by Name. Only the latest version of a statistic is returned. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* Statistics = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Statistics;
 };
 
 USTRUCT(BlueprintType)
@@ -554,10 +554,10 @@ struct PLAYFAB_API FProgressionGetStatisticsForEntitiesRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Collection of Entity IDs to retrieve statistics for. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        TArray<UPlayFabJsonObject*> Entities;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Entities;
     /** The list of statistics to return for the user. If set to null, the current version of all statistics are returned. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString StatisticNames;
@@ -570,10 +570,10 @@ struct PLAYFAB_API FProgressionGetStatisticsForEntitiesResponse : public FPlayFa
 public:
     /** A mapping of statistic name to the columns defined in the corresponding definition. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* ColumnDetails = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ColumnDetails;
     /** List of entities mapped to their statistics. Only the latest version of a statistic is returned. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        TArray<UPlayFabJsonObject*> EntitiesStatistics;
+        TArray<TObjectPtr<UPlayFabJsonObject>> EntitiesStatistics;
 };
 
 USTRUCT(BlueprintType)
@@ -583,7 +583,7 @@ struct PLAYFAB_API FProgressionIncrementStatisticVersionRequest : public FPlayFa
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Name of the statistic to increment the version of. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString Name;
@@ -606,7 +606,7 @@ struct PLAYFAB_API FProgressionListStatisticDefinitionsRequest : public FPlayFab
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The page size for the request. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         int32 PageSize = 0;
@@ -628,7 +628,7 @@ public:
         FString SkipToken;
     /** List of statistic definitions for the title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        TArray<UPlayFabJsonObject*> StatisticDefinitions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> StatisticDefinitions;
 };
 
 USTRUCT(BlueprintType)
@@ -638,7 +638,7 @@ struct PLAYFAB_API FProgressionUnlinkAggregationSourceFromStatisticRequest : pub
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the statistic to unlink. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString Name;
@@ -654,16 +654,16 @@ struct PLAYFAB_API FProgressionUpdateStatisticDefinitionRequest : public FPlayFa
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** [In Preview]: Configurations for different Statistics events that can be emitted by the service. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* EventEmissionConfig = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EventEmissionConfig;
     /** Name of the statistic. Must be less than 150 characters. Restricted to a-Z, 0-9, '(', ')', '_', '-' and '.'. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString Name;
     /** The version reset configuration for the statistic definition. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* VersionConfiguration = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VersionConfiguration;
 };
 
 USTRUCT(BlueprintType)
@@ -673,13 +673,13 @@ struct PLAYFAB_API FProgressionUpdateStatisticsRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Collection of statistics to update, maximum 50. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        TArray<UPlayFabJsonObject*> Statistics;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statistics;
     /** Optional transactionId of this update which can be used to ensure idempotence. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
         FString TransactionId;
@@ -692,12 +692,12 @@ struct PLAYFAB_API FProgressionUpdateStatisticsResponse : public FPlayFabResultC
 public:
     /** A mapping of statistic name to the columns defined in the corresponding definition. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* ColumnDetails = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ColumnDetails;
     /** The entity id and type. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* Entity = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Entity;
     /** Updated entity profile statistics. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Progression | Statistics Models")
-        UPlayFabJsonObject* Statistics = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Statistics;
 };
 

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabRequestCommon.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabRequestCommon.h
@@ -18,5 +18,5 @@ struct PLAYFAB_API FPlayFabRequestCommon
 
     // An optional authentication context (can used in multi-user scenarios)
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Core")
-        UPlayFabAuthenticationContext* AuthenticationContext = nullptr;
+        TObjectPtr<UPlayFabAuthenticationContext> AuthenticationContext;
 };

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabResultCommon.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabResultCommon.h
@@ -15,5 +15,5 @@ struct PLAYFAB_API FPlayFabResultCommon
     GENERATED_BODY()
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "PlayFab | Core")
-        UPlayFabJsonObject* Request = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Request;
 };

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabServerAPI.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabServerAPI.h
@@ -2562,7 +2562,7 @@ public:
 
 private:
     UPROPERTY()
-        UPlayFabAuthenticationContext* CallAuthenticationContext;
+        TObjectPtr<UPlayFabAuthenticationContext> CallAuthenticationContext;
 
     /** Internal bind function for the IHTTPRequest::OnProcessRequestCompleted() event */
     void OnProcessRequestComplete(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
@@ -2570,11 +2570,11 @@ private:
 protected:
     /** Internal request data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* RequestJsonObj;
+        TObjectPtr<UPlayFabJsonObject> RequestJsonObj;
 
     /** Response data stored as JSON */
     UPROPERTY()
-        UPlayFabJsonObject* ResponseJsonObj;
+        TObjectPtr<UPlayFabJsonObject> ResponseJsonObj;
 
     /** Mapping of header section to values. Used to generate final header string for request */
     TMap<FString, FString> RequestHeaders;

--- a/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabServerModels.h
+++ b/5.7/PlayFabPlugin/PlayFab/Source/PlayFab/Classes/PlayFabServerModels.h
@@ -37,7 +37,7 @@ struct PLAYFAB_API FServerAddGenericIDRequest : public FPlayFabRequestCommon
 public:
     /** Generic service identifier to add to the player account. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* GenericId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> GenericId;
     /** PlayFabId of the user to link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PlayFabId;
@@ -61,7 +61,7 @@ struct PLAYFAB_API FServerAddOrUpdateContactEmailRequest : public FPlayFabReques
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The new contact email to associate with the player. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString EmailAddress;
@@ -88,10 +88,10 @@ struct PLAYFAB_API FServerBanUsersRequest : public FPlayFabRequestCommon
 public:
     /** List of ban requests to be applied. Maximum 100. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Bans;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Bans;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
 };
 
 USTRUCT(BlueprintType)
@@ -101,7 +101,7 @@ struct PLAYFAB_API FServerBanUsersResult : public FPlayFabResultCommon
 public:
     /** Information on the bans that were applied */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> BanData;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BanData;
 };
 
 /**
@@ -162,7 +162,7 @@ struct PLAYFAB_API FServerGetPlayerProfileRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PlayFabId;
@@ -172,7 +172,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
 };
 
 USTRUCT(BlueprintType)
@@ -185,7 +185,7 @@ public:
      * exist.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* PlayerProfile = nullptr;
+        TObjectPtr<UPlayFabJsonObject> PlayerProfile;
 };
 
 USTRUCT(BlueprintType)
@@ -209,7 +209,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromBattleNetAccountIdsResult : public FP
 public:
     /** Mapping of Battle.net account identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -233,7 +233,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromFacebookIDsResult : public FPlayFabRe
 public:
     /** Mapping of Facebook identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -257,7 +257,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromFacebookInstantGamesIdsResult : publi
 public:
     /** Mapping of Facebook Instant Games identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -270,7 +270,7 @@ public:
      * maximum of 10 in a single request.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> GenericIDs;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GenericIDs;
 };
 
 /** For generic service identifiers which have not been linked to PlayFab accounts, null will be returned. */
@@ -281,7 +281,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromGenericIDsResult : public FPlayFabRes
 public:
     /** Mapping of generic service identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -305,7 +305,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromNintendoServiceAccountIdsResult : pub
 public:
     /** Mapping of Nintendo Switch Service Account identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -329,7 +329,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromNintendoSwitchDeviceIdsResult : publi
 public:
     /** Mapping of Nintendo Switch Device identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -342,7 +342,7 @@ public:
      * 10 in length.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> OpenIdSubjectIdentifiers;
+        TArray<TObjectPtr<UPlayFabJsonObject>> OpenIdSubjectIdentifiers;
 };
 
 /** For OpenId identifiers which have not been linked to PlayFab accounts, null will be returned. */
@@ -353,7 +353,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromOpenIdsResult : public FPlayFabResult
 public:
     /** Mapping of OpenId Connect identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -380,7 +380,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromPSNAccountIDsResult : public FPlayFab
 public:
     /** Mapping of PlayStation :tm: Network identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -407,7 +407,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromPSNOnlineIDsResult : public FPlayFabR
 public:
     /** Mapping of PlayStation :tm: Network identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -431,7 +431,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromSteamIDsResult : public FPlayFabResul
 public:
     /** Mapping of Steam identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -455,7 +455,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromSteamNamesResult : public FPlayFabRes
 public:
     /** Mapping of Steam identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -479,7 +479,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromTwitchIDsResult : public FPlayFabResu
 public:
     /** Mapping of Twitch identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -506,7 +506,7 @@ struct PLAYFAB_API FServerGetPlayFabIDsFromXboxLiveIDsResult : public FPlayFabRe
 public:
     /** Mapping of Xbox Live identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -530,7 +530,7 @@ struct PLAYFAB_API FServerGetServerCustomIDsFromPlayFabIDsResult : public FPlayF
 public:
     /** Mapping of server custom player identifiers to PlayFab identifiers. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Data;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Data;
 };
 
 /**
@@ -556,7 +556,7 @@ struct PLAYFAB_API FServerGetUserAccountInfoResult : public FPlayFabResultCommon
 public:
     /** Account details for the user whose information was requested. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* UserInfo = nullptr;
+        TObjectPtr<UPlayFabJsonObject> UserInfo;
 };
 
 /** Get all bans for a user, including inactive and expired bans. */
@@ -577,7 +577,7 @@ struct PLAYFAB_API FServerGetUserBansResult : public FPlayFabResultCommon
 public:
     /** Information about the bans */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> BanData;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BanData;
 };
 
 USTRUCT(BlueprintType)
@@ -587,7 +587,7 @@ struct PLAYFAB_API FServerLinkBattleNetAccountRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to a specific Battle.net account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         bool ForceLink = false;
@@ -606,7 +606,7 @@ struct PLAYFAB_API FServerLinkNintendoServiceAccountRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to a specific Nintendo Switch account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         bool ForceLink = false;
@@ -628,7 +628,7 @@ struct PLAYFAB_API FServerLinkNintendoServiceAccountSubjectRequest : public FPla
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to a specific Nintendo Service Account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         bool ForceLink = false;
@@ -647,7 +647,7 @@ struct PLAYFAB_API FServerLinkNintendoSwitchDeviceIdRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the Nintendo Switch Device ID, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         bool ForceLink = false;
@@ -676,7 +676,7 @@ public:
         FString AuthCode;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         bool ForceLink = false;
@@ -705,7 +705,7 @@ struct PLAYFAB_API FServerLinkPSNIdRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         bool ForceLink = false;
@@ -734,7 +734,7 @@ struct PLAYFAB_API FServerLinkServerCustomIdRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the custom ID, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         bool ForceLink = false;
@@ -760,7 +760,7 @@ struct PLAYFAB_API FServerLinkSteamIdRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         bool ForceLink = false;
@@ -789,7 +789,7 @@ public:
         FString AccessToken;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         bool ForceLink = false;
@@ -805,7 +805,7 @@ struct PLAYFAB_API FServerLinkXboxAccountRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         bool ForceLink = false;
@@ -831,7 +831,7 @@ struct PLAYFAB_API FServerLinkXboxIdRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** If another user is already linked to the account, unlink the other user and re-link. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         bool ForceLink = false;
@@ -853,7 +853,7 @@ struct PLAYFAB_API FServerRemoveGenericIDRequest : public FPlayFabRequestCommon
 public:
     /** Generic service identifier to be removed from the player. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* GenericId = nullptr;
+        TObjectPtr<UPlayFabJsonObject> GenericId;
     /** PlayFabId of the user to remove. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PlayFabId;
@@ -880,7 +880,7 @@ struct PLAYFAB_API FServerRevokeAllBansForUserResult : public FPlayFabResultComm
 public:
     /** Information on the bans that were revoked. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> BanData;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BanData;
 };
 
 /**
@@ -904,7 +904,7 @@ struct PLAYFAB_API FServerRevokeBansResult : public FPlayFabResultCommon
 public:
     /** Information on the bans that were revoked */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> BanData;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BanData;
 };
 
 /** Represents the save push notification template request. */
@@ -924,7 +924,7 @@ public:
         FString IOSPayload;
     /** Dictionary of localized push notification templates with the language as the key. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* LocalizedPushNotificationTemplates = nullptr;
+        TObjectPtr<UPlayFabJsonObject> LocalizedPushNotificationTemplates;
     /** Name of the push notification template. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString Name;
@@ -952,7 +952,7 @@ struct PLAYFAB_API FServerSendCustomAccountRecoveryEmailRequest : public FPlayFa
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** User email address attached to their account */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString Email;
@@ -982,7 +982,7 @@ struct PLAYFAB_API FServerSendEmailFromTemplateRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The email template id of the email template to send. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString EmailTemplateId;
@@ -1008,10 +1008,10 @@ public:
      * to custom plugin logic, fields, or functionality not natively supported by PlayFab.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> AdvancedPlatformDelivery;
+        TArray<TObjectPtr<UPlayFabJsonObject>> AdvancedPlatformDelivery;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Text of message to send. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString Message;
@@ -1020,7 +1020,7 @@ public:
      * the PushNotificationPackage documentation for details.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* Package = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Package;
     /** PlayFabId of the recipient of the push notification. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString Recipient;
@@ -1047,7 +1047,7 @@ struct PLAYFAB_API FServerSendPushNotificationFromTemplateRequest : public FPlay
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Id of the push notification template. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PushNotificationTemplateId;
@@ -1070,7 +1070,7 @@ struct PLAYFAB_API FServerUnlinkBattleNetAccountRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PlayFabId;
@@ -1083,7 +1083,7 @@ struct PLAYFAB_API FServerUnlinkFacebookAccountRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** PlayFab unique identifier of the user to unlink. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PlayFabId;
@@ -1103,7 +1103,7 @@ struct PLAYFAB_API FServerUnlinkFacebookInstantGamesIdRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Facebook Instant Games identifier for the user. If not specified, the most recently linked identifier will be used. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString FacebookInstantGamesId;
@@ -1126,7 +1126,7 @@ struct PLAYFAB_API FServerUnlinkNintendoServiceAccountRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PlayFabId;
@@ -1139,7 +1139,7 @@ struct PLAYFAB_API FServerUnlinkNintendoSwitchDeviceIdRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Nintendo Switch Device identifier for the user. If not specified, the most recently signed in device ID will be used. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString NintendoSwitchDeviceId;
@@ -1162,7 +1162,7 @@ struct PLAYFAB_API FServerUnlinkPSNAccountRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PlayFabId;
@@ -1182,7 +1182,7 @@ struct PLAYFAB_API FServerUnlinkServerCustomIdRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab identifier. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PlayFabId;
@@ -1205,7 +1205,7 @@ struct PLAYFAB_API FServerUnlinkSteamIdRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab identifier for a user, or null if no PlayFab account is linked to the Steam account. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PlayFabId;
@@ -1231,7 +1231,7 @@ public:
         FString AccessToken;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** PlayFab unique identifier of the user to unlink. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PlayFabId;
@@ -1244,7 +1244,7 @@ struct PLAYFAB_API FServerUnlinkXboxAccountRequest : public FPlayFabRequestCommo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** PlayFab unique identifier of the user to unlink. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
         FString PlayFabId;
@@ -1281,7 +1281,7 @@ struct PLAYFAB_API FServerUpdateBansRequest : public FPlayFabRequestCommon
 public:
     /** List of bans to be updated. Maximum 100. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> Bans;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Bans;
 };
 
 USTRUCT(BlueprintType)
@@ -1291,7 +1291,7 @@ struct PLAYFAB_API FServerUpdateBansResult : public FPlayFabResultCommon
 public:
     /** Information on the bans that were updated */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Account Management Models")
-        TArray<UPlayFabJsonObject*> BanData;
+        TArray<TObjectPtr<UPlayFabJsonObject>> BanData;
 };
 
 
@@ -1324,13 +1324,13 @@ struct PLAYFAB_API FServerWriteServerCharacterEventRequest : public FPlayFabRequ
 public:
     /** Custom event properties. Each property consists of a name (string) and a value (JSON object). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Analytics Models")
-        UPlayFabJsonObject* Body = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Body;
     /** Unique PlayFab assigned ID for a specific character owned by a user */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Analytics Models")
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Analytics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The name of the event, within the namespace scoped to the title. The naming convention is up to the caller, but it
      * commonly follows the subject_verb_object pattern (e.g. player_logged_in).
@@ -1357,10 +1357,10 @@ struct PLAYFAB_API FServerWriteServerPlayerEventRequest : public FPlayFabRequest
 public:
     /** Custom data properties associated with the event. Each property consists of a name (string) and a value (JSON object). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Analytics Models")
-        UPlayFabJsonObject* Body = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Body;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Analytics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The name of the event, within the namespace scoped to the title. The naming convention is up to the caller, but it
      * commonly follows the subject_verb_object pattern (e.g. player_logged_in).
@@ -1387,10 +1387,10 @@ struct PLAYFAB_API FServerWriteTitleEventRequest : public FPlayFabRequestCommon
 public:
     /** Custom event properties. Each property consists of a name (string) and a value (JSON object). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Analytics Models")
-        UPlayFabJsonObject* Body = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Body;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Analytics Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * The name of the event, within the namespace scoped to the title. The naming convention is up to the caller, but it
      * commonly follows the subject_verb_object pattern (e.g. player_logged_in).
@@ -1432,7 +1432,7 @@ public:
         bool IsSessionTicketExpired = false;
     /** Account info for the user whose session ticket was supplied. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* UserInfo = nullptr;
+        TObjectPtr<UPlayFabJsonObject> UserInfo;
 };
 
 /**
@@ -1463,10 +1463,10 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Specific Operating System version for the user's device. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
         FString OS;
@@ -1482,10 +1482,10 @@ public:
      * returned.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* EntityToken = nullptr;
+        TObjectPtr<UPlayFabJsonObject> EntityToken;
     /** Results for requested info. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* InfoResultPayload = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoResultPayload;
     /** The time of this user's previous login. If there was no previous login, then it's DateTime.MinValue */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
         FString LastLoginTime;
@@ -1500,10 +1500,10 @@ public:
         FString SessionTicket;
     /** Settings specific to this user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* SettingsForUser = nullptr;
+        TObjectPtr<UPlayFabJsonObject> SettingsForUser;
     /** The experimentation treatments for this user at the time of login. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* TreatmentAssignment = nullptr;
+        TObjectPtr<UPlayFabJsonObject> TreatmentAssignment;
 };
 
 USTRUCT(BlueprintType)
@@ -1516,13 +1516,13 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The JSON Web Token (JWT) returned by Battle.net after login */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
         FString IdentityToken;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
 };
 
 /**
@@ -1545,10 +1545,10 @@ public:
         FString CustomId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
 };
 
 /**
@@ -1571,7 +1571,7 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Vendor-specific iOS identifier for the user's device. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
         FString DeviceId;
@@ -1580,7 +1580,7 @@ public:
         FString DeviceModel;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Specific Operating System version for the user's device. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
         FString OS;
@@ -1606,10 +1606,10 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Id of the PlayStation :tm: Network issuer environment. If null, defaults to production environment. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
         int32 IssuerId = 0;
@@ -1628,10 +1628,10 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret that is used to verify API request signatures (Enterprise Only). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
         FString PlayerSecret;
@@ -1658,10 +1658,10 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Unique Steam identifier for a user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
         FString SteamId;
@@ -1689,10 +1689,10 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Parameters for requesting additional player info. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Player secret for additional authentication. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
         FString PlayerSecret;
@@ -1717,10 +1717,10 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** Token provided by the Xbox Live SDK/XDK method GetTokenAndSignatureAsync("POST", "https://playfabapi.com/", ""). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
         FString XboxToken;
@@ -1742,10 +1742,10 @@ public:
         bool CreateAccount = false;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** The id of Xbox Live sandbox. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Authentication Models")
         FString Sandbox;
@@ -1823,7 +1823,7 @@ public:
         FString CharacterId;
     /** User specific data for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Character Data Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Indicates the current version of the data that has been set. This is incremented with every set call for that type of
      * data (read-only, internal, etc). This version can be provided in Get calls to find updated data.
@@ -1850,13 +1850,13 @@ public:
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Character Data Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Key-value pairs to be written to the custom data. Note that keys are trimmed of whitespace, are limited in size, and may
      * not begin with a '!' character or be null.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Character Data Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Optional list of Data-keys to remove from UserData. Some SDKs cannot insert null-values into Data due to language
      * constraints. Use this to delete the keys directly.
@@ -1904,7 +1904,7 @@ public:
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
         FString PlayFabId;
@@ -1941,7 +1941,7 @@ struct PLAYFAB_API FServerListUsersCharactersResult : public FPlayFabResultCommo
 public:
     /** The requested list of characters. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
-        TArray<UPlayFabJsonObject*> Characters;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Characters;
 };
 
 USTRUCT(BlueprintType)
@@ -1968,7 +1968,7 @@ struct PLAYFAB_API FServerGetCharacterLeaderboardResult : public FPlayFabResultC
 public:
     /** Ordered list of leaderboard entries. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
-        TArray<UPlayFabJsonObject*> Leaderboard;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Leaderboard;
 };
 
 /**
@@ -1999,7 +1999,7 @@ public:
         FString CharacterId;
     /** Character statistics for the requested user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
-        UPlayFabJsonObject* CharacterStatistics = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CharacterStatistics;
     /** PlayFab unique identifier of the user whose character statistics are being returned. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
         FString PlayFabId;
@@ -2035,7 +2035,7 @@ struct PLAYFAB_API FServerGetLeaderboardAroundCharacterResult : public FPlayFabR
 public:
     /** Ordered list of leaderboard entries. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
-        TArray<UPlayFabJsonObject*> Leaderboard;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Leaderboard;
 };
 
 USTRUCT(BlueprintType)
@@ -2063,7 +2063,7 @@ struct PLAYFAB_API FServerGetLeaderboardForUsersCharactersResult : public FPlayF
 public:
     /** Ordered list of leaderboard entries. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
-        TArray<UPlayFabJsonObject*> Leaderboard;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Leaderboard;
 };
 
 /** Grants a character to the user of the type and name specified in the request. */
@@ -2080,7 +2080,7 @@ public:
         FString CharacterType;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
         FString PlayFabId;
@@ -2111,10 +2111,10 @@ public:
         FString CharacterId;
     /** Statistics to be updated with the provided values. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
-        UPlayFabJsonObject* CharacterStatistics = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CharacterStatistics;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Characters Models")
         FString PlayFabId;
@@ -2195,7 +2195,7 @@ struct PLAYFAB_API FServerGetFriendsListRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Friend List Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Indicates which other platforms' friends should be included in the response. In HTTP, it is represented as a
      * comma-separated list of platforms.
@@ -2211,7 +2211,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Friend List Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
     /**
      * Xbox token if Xbox friends should be included. Requires Xbox be configured on PlayFab. When provided, all Xbox Live
      * users the caller is following are included regardless of whether they follow the caller back.
@@ -2235,7 +2235,7 @@ struct PLAYFAB_API FServerGetFriendsListResult : public FPlayFabResultCommon
 public:
     /** Array of friends found. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Friend List Management Models")
-        TArray<UPlayFabJsonObject*> Friends;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Friends;
 };
 
 USTRUCT(BlueprintType)
@@ -2289,7 +2289,7 @@ struct PLAYFAB_API FServerAwardSteamAchievementRequest : public FPlayFabRequestC
 public:
     /** Array of achievements to grant and the users to whom they are to be granted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Platform Specific Methods Models")
-        TArray<UPlayFabJsonObject*> Achievements;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Achievements;
 };
 
 USTRUCT(BlueprintType)
@@ -2299,7 +2299,7 @@ struct PLAYFAB_API FServerAwardSteamAchievementResult : public FPlayFabResultCom
 public:
     /** Array of achievements granted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Platform Specific Methods Models")
-        TArray<UPlayFabJsonObject*> AchievementResults;
+        TArray<TObjectPtr<UPlayFabJsonObject>> AchievementResults;
 };
 
 
@@ -2315,7 +2315,7 @@ struct PLAYFAB_API FServerDeletePlayerCustomPropertiesRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Optional field used for concurrency control. One can ensure that the delete operation will only be performed if the
      * player's properties have not been updated by any other clients since the last version.
@@ -2337,7 +2337,7 @@ struct PLAYFAB_API FServerDeletePlayerCustomPropertiesResult : public FPlayFabRe
 public:
     /** The list of properties requested to be deleted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> DeletedProperties;
+        TArray<TObjectPtr<UPlayFabJsonObject>> DeletedProperties;
     /** PlayFab unique identifier of the user whose properties were deleted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         FString PlayFabId;
@@ -2356,7 +2356,7 @@ struct PLAYFAB_API FServerGetFriendLeaderboardRequest : public FPlayFabRequestCo
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Indicates which other platforms' friends should be included in the response. In HTTP, it is represented as a
      * comma-separated list of platforms.
@@ -2375,7 +2375,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
     /** Position in the leaderboard to start this listing (defaults to the first entry). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         int32 StartPosition = 0;
@@ -2401,7 +2401,7 @@ struct PLAYFAB_API FServerGetLeaderboardResult : public FPlayFabResultCommon
 public:
     /** Ordered listing of users and their positions in the requested leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Leaderboard;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Leaderboard;
     /** The time the next scheduled reset will occur. Null if the leaderboard does not reset on a schedule. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         FString NextReset;
@@ -2417,7 +2417,7 @@ struct PLAYFAB_API FServerGetLeaderboardRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Maximum number of entries to retrieve. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         int32 MaxResultsCount = 0;
@@ -2427,7 +2427,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
     /** First entry in the leaderboard to be retrieved. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         int32 StartPosition = 0;
@@ -2449,7 +2449,7 @@ struct PLAYFAB_API FServerGetLeaderboardAroundUserRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Maximum number of entries to retrieve. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         int32 MaxResultsCount = 0;
@@ -2462,7 +2462,7 @@ public:
      * the Game Manager "Client Profile Options" tab in the "Settings" section.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* ProfileConstraints = nullptr;
+        TObjectPtr<UPlayFabJsonObject> ProfileConstraints;
     /** Unique identifier for the title-specific statistic for the leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         FString StatisticName;
@@ -2485,7 +2485,7 @@ struct PLAYFAB_API FServerGetLeaderboardAroundUserResult : public FPlayFabResult
 public:
     /** Ordered listing of users and their positions in the requested leaderboard. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Leaderboard;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Leaderboard;
     /** The time the next scheduled reset will occur. Null if the leaderboard does not reset on a schedule. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         FString NextReset;
@@ -2501,10 +2501,10 @@ struct PLAYFAB_API FServerGetPlayerCombinedInfoRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Flags for which pieces of info to return for the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* InfoRequestParameters = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoRequestParameters;
     /** PlayFabId of the user whose data will be returned */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         FString PlayFabId;
@@ -2517,7 +2517,7 @@ struct PLAYFAB_API FServerGetPlayerCombinedInfoResult : public FPlayFabResultCom
 public:
     /** Results for requested info. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* InfoResultPayload = nullptr;
+        TObjectPtr<UPlayFabJsonObject> InfoResultPayload;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         FString PlayFabId;
@@ -2552,7 +2552,7 @@ public:
         int32 PropertiesVersion = 0;
     /** Player specific property and its corresponding value. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* Property = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Property;
 };
 
 USTRUCT(BlueprintType)
@@ -2562,7 +2562,7 @@ struct PLAYFAB_API FServerGetPlayerStatisticsRequest : public FPlayFabRequestCom
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** user for whom statistics are being requested */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         FString PlayFabId;
@@ -2574,7 +2574,7 @@ public:
      * returned)
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> StatisticNameVersions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> StatisticNameVersions;
 };
 
 /** In addition to being available for use by the title, the statistics are used for all leaderboard operations in PlayFab. */
@@ -2588,7 +2588,7 @@ public:
         FString PlayFabId;
     /** User statistics for the requested user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Statistics;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statistics;
 };
 
 USTRUCT(BlueprintType)
@@ -2598,7 +2598,7 @@ struct PLAYFAB_API FServerGetPlayerStatisticVersionsRequest : public FPlayFabReq
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** unique name of the statistic */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
         FString StatisticName;
@@ -2611,7 +2611,7 @@ struct PLAYFAB_API FServerGetPlayerStatisticVersionsResult : public FPlayFabResu
 public:
     /** version change history of the statistic */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> StatisticVersions;
+        TArray<TObjectPtr<UPlayFabJsonObject>> StatisticVersions;
 };
 
 /**
@@ -2644,7 +2644,7 @@ struct PLAYFAB_API FServerGetUserDataResult : public FPlayFabResultCommon
 public:
     /** User specific data for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Indicates the current version of the data that has been set. This is incremented with every set call for that type of
      * data (read-only, internal, etc). This version can be provided in Get calls to find updated data.
@@ -2676,7 +2676,7 @@ public:
         FString PlayFabId;
     /** Player specific properties and their corresponding values for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Properties;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Properties;
     /**
      * Indicates the current version of a player's properties that have been set. This is incremented after updates and
      * deletes. This version can be provided in update and delete calls for concurrency control.
@@ -2697,7 +2697,7 @@ struct PLAYFAB_API FServerUpdatePlayerCustomPropertiesRequest : public FPlayFabR
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Optional field used for concurrency control. One can ensure that the update operation will only be performed if the
      * player's properties have not been updated by any other clients since last the version.
@@ -2709,7 +2709,7 @@ public:
         FString PlayFabId;
     /** Collection of properties to be set for a player. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Properties;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Properties;
 };
 
 USTRUCT(BlueprintType)
@@ -2739,7 +2739,7 @@ struct PLAYFAB_API FServerUpdatePlayerStatisticsRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Indicates whether the statistics provided should be set, regardless of the aggregation method set on the statistic.
      * Default is false.
@@ -2751,7 +2751,7 @@ public:
         FString PlayFabId;
     /** Statistics to be updated with the provided values */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        TArray<UPlayFabJsonObject*> Statistics;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Statistics;
 };
 
 USTRUCT(BlueprintType)
@@ -2773,13 +2773,13 @@ struct PLAYFAB_API FServerUpdateUserDataRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Key-value pairs to be written to the custom data. Note that keys are trimmed of whitespace, are limited in size, and may
      * not begin with a '!' character or be null.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Optional list of Data-keys to remove from UserData. Some SDKs cannot insert null-values into Data due to language
      * constraints. Use this to delete the keys directly.
@@ -2819,13 +2819,13 @@ struct PLAYFAB_API FServerUpdateUserInternalDataRequest : public FPlayFabRequest
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Key-value pairs to be written to the custom data. Note that keys are trimmed of whitespace, are limited in size, and may
      * not begin with a '!' character or be null.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Optional list of Data-keys to remove from UserData. Some SDKs cannot insert null-values into Data due to language
      * constraints. Use this to delete the keys directly.
@@ -2858,7 +2858,7 @@ public:
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** PlayFab unique identifier of the user whose virtual currency balance is to be incremented. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString PlayFabId;
@@ -2893,7 +2893,7 @@ public:
         int32 Amount = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** PlayFab unique identifier of the user whose virtual currency balance is to be increased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString PlayFabId;
@@ -2937,7 +2937,7 @@ public:
         int32 ConsumeCount = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique instance identifier of the item to be consumed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString ItemInstanceId;
@@ -3007,7 +3007,7 @@ public:
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString PlayFabId;
@@ -3023,16 +3023,16 @@ public:
         FString CharacterId;
     /** Array of inventory items belonging to the character. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Inventory;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Inventory;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString PlayFabId;
     /** Array of virtual currency balance(s) belonging to the character. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrency = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrency;
     /** Array of remaining times and timestamps for virtual currencies. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrencyRechargeTimes = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrencyRechargeTimes;
 };
 
 USTRUCT(BlueprintType)
@@ -3062,7 +3062,7 @@ struct PLAYFAB_API FServerGetRandomResultTablesResult : public FPlayFabResultCom
 public:
     /** array of random result tables currently available */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* Tables = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Tables;
 };
 
 /**
@@ -3077,7 +3077,7 @@ struct PLAYFAB_API FServerGetUserInventoryRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString PlayFabId;
@@ -3090,16 +3090,16 @@ struct PLAYFAB_API FServerGetUserInventoryResult : public FPlayFabResultCommon
 public:
     /** Array of inventory items belonging to the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Inventory;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Inventory;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString PlayFabId;
     /** Array of virtual currency balance(s) belonging to the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrency = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrency;
     /** Array of remaining times and timestamps for virtual currencies. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrencyRechargeTimes = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrencyRechargeTimes;
 };
 
 /**
@@ -3124,7 +3124,7 @@ public:
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Array of itemIds to grant to the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString ItemIds;
@@ -3140,7 +3140,7 @@ struct PLAYFAB_API FServerGrantItemsToCharacterResult : public FPlayFabResultCom
 public:
     /** Array of items granted to users. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> ItemGrantResults;
+        TArray<TObjectPtr<UPlayFabJsonObject>> ItemGrantResults;
 };
 
 /**
@@ -3162,7 +3162,7 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Array of itemIds to grant to the user. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString ItemIds;
@@ -3179,7 +3179,7 @@ struct PLAYFAB_API FServerGrantItemsToUserResult : public FPlayFabResultCommon
 public:
     /** Array of items granted to users. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> ItemGrantResults;
+        TArray<TObjectPtr<UPlayFabJsonObject>> ItemGrantResults;
 };
 
 /**
@@ -3198,10 +3198,10 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Array of items to grant and the users to whom the items are to be granted. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> ItemGrants;
+        TArray<TObjectPtr<UPlayFabJsonObject>> ItemGrants;
 };
 
 /** Please note that the order of the items in the response may not match the order of items in the request. */
@@ -3212,7 +3212,7 @@ struct PLAYFAB_API FServerGrantItemsToUsersResult : public FPlayFabResultCommon
 public:
     /** Array of items granted to users. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> ItemGrantResults;
+        TArray<TObjectPtr<UPlayFabJsonObject>> ItemGrantResults;
 };
 
 /**
@@ -3226,7 +3226,7 @@ struct PLAYFAB_API FServerModifyItemUsesRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique instance identifier of the item to be modified. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString ItemInstanceId;
@@ -3357,7 +3357,7 @@ public:
         FString CouponCode;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString PlayFabId;
@@ -3370,7 +3370,7 @@ struct PLAYFAB_API FServerRedeemCouponResult : public FPlayFabResultCommon
 public:
     /** Items granted to the player as a result of redeeming the coupon. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> GrantedItems;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GrantedItems;
 };
 
 USTRUCT(BlueprintType)
@@ -3383,7 +3383,7 @@ public:
         FString Comment;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab identifier of the reported player. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString ReporteeId;
@@ -3444,7 +3444,7 @@ struct PLAYFAB_API FServerRevokeInventoryItemsRequest : public FPlayFabRequestCo
 public:
     /** Array of player items to revoke, between 1 and 25 items. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Items;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Items;
 };
 
 USTRUCT(BlueprintType)
@@ -3454,7 +3454,7 @@ struct PLAYFAB_API FServerRevokeInventoryItemsResult : public FPlayFabResultComm
 public:
     /** Collection of any errors that occurred during processing. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> Errors;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Errors;
 };
 
 USTRUCT(BlueprintType)
@@ -3470,7 +3470,7 @@ public:
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString PlayFabId;
@@ -3489,7 +3489,7 @@ public:
         int32 Amount = 0;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** PlayFab unique identifier of the user whose virtual currency balance is to be decreased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString PlayFabId;
@@ -3518,7 +3518,7 @@ public:
         FString ContainerItemInstanceId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * ItemInstanceId of the key that will be consumed by unlocking this container. If the container requires a key, this
      * parameter is required.
@@ -3538,7 +3538,7 @@ struct PLAYFAB_API FServerUnlockContainerItemResult : public FPlayFabResultCommo
 public:
     /** Items granted to the player as a result of unlocking the container. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        TArray<UPlayFabJsonObject*> GrantedItems;
+        TArray<TObjectPtr<UPlayFabJsonObject>> GrantedItems;
     /** Unique instance identifier of the container unlocked. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString UnlockedItemInstanceId;
@@ -3547,7 +3547,7 @@ public:
         FString UnlockedWithItemInstanceId;
     /** Virtual currency granted to the player as a result of unlocking the container. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* VirtualCurrency = nullptr;
+        TObjectPtr<UPlayFabJsonObject> VirtualCurrency;
 };
 
 /** Specify the type of container to open and optionally the catalogVersion for the container to open */
@@ -3570,7 +3570,7 @@ public:
         FString ContainerItemId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString PlayFabId;
@@ -3592,13 +3592,13 @@ public:
         FString CharacterId;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Key-value pairs to be written to the custom data. Note that keys are trimmed of whitespace, are limited in size, and may
      * not begin with a '!' character or be null.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /** Unique PlayFab assigned instance identifier of the item */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Player Item Management Models")
         FString ItemInstanceId;
@@ -3630,7 +3630,7 @@ struct PLAYFAB_API FServerAddPlayerTagRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | PlayStream Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | PlayStream Models")
         FString PlayFabId;
@@ -3685,7 +3685,7 @@ struct PLAYFAB_API FServerGetAllSegmentsResult : public FPlayFabResultCommon
 public:
     /** Array of segments for this title. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | PlayStream Models")
-        TArray<UPlayFabJsonObject*> Segments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Segments;
 };
 
 USTRUCT(BlueprintType)
@@ -3695,7 +3695,7 @@ struct PLAYFAB_API FServerGetPlayerSegmentsResult : public FPlayFabResultCommon
 public:
     /** Array of segments the requested player currently belongs to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | PlayStream Models")
-        TArray<UPlayFabJsonObject*> Segments;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Segments;
 };
 
 USTRUCT(BlueprintType)
@@ -3705,7 +3705,7 @@ struct PLAYFAB_API FServerGetPlayersSegmentsRequest : public FPlayFabRequestComm
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | PlayStream Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | PlayStream Models")
         FString PlayFabId;
@@ -3723,7 +3723,7 @@ struct PLAYFAB_API FServerGetPlayerTagsRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | PlayStream Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Optional namespace to filter results by */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | PlayStream Models")
         FString Namespace;
@@ -3780,7 +3780,7 @@ struct PLAYFAB_API FServerRemovePlayerTagRequest : public FPlayFabRequestCommon
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | PlayStream Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | PlayStream Models")
         FString PlayFabId;
@@ -3811,7 +3811,7 @@ public:
         int32 APIRequestsIssued = 0;
     /** Information about the error, if any, that occurred during execution */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* Error = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Error;
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Server-Side Cloud Script Models")
         int32 ExecutionTimeSeconds = 0;
     /** The name of the function that executed */
@@ -3819,7 +3819,7 @@ public:
         FString FunctionName;
     /** The object returned from the CloudScript function, if any */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionResult = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionResult;
     /**
      * Flag indicating if the FunctionResult was too large and was subsequently dropped from this event. This only occurs if
      * the total event size is larger than 350KB.
@@ -3834,7 +3834,7 @@ public:
      * and log.error() and error entries for API and HTTP request failures.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Server-Side Cloud Script Models")
-        TArray<UPlayFabJsonObject*> Logs;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Logs;
     /**
      * Flag indicating if the logs were too large and were subsequently dropped from this event. This only occurs if the total
      * event size is larger than 350KB after the FunctionResult was removed.
@@ -3861,13 +3861,13 @@ struct PLAYFAB_API FServerExecuteCloudScriptServerRequest : public FPlayFabReque
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /** The name of the CloudScript function to execute */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Server-Side Cloud Script Models")
         FString FunctionName;
     /** Object that is passed in to the function as the first argument */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Server-Side Cloud Script Models")
-        UPlayFabJsonObject* FunctionParameter = nullptr;
+        TObjectPtr<UPlayFabJsonObject> FunctionParameter;
     /**
      * Generate a 'player_executed_cloudscript' PlayStream event containing the results of the function execution and other
      * contextual information. This event will show up in the PlayStream debugger console for the player in Game Manager.
@@ -3974,7 +3974,7 @@ struct PLAYFAB_API FServerGetSharedGroupDataResult : public FPlayFabResultCommon
 public:
     /** Data for the requested keys. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Shared Group Data Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /** List of PlayFabId identifiers for the members of this group, if requested. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Shared Group Data Models")
         FString Members;
@@ -4013,13 +4013,13 @@ struct PLAYFAB_API FServerUpdateSharedGroupDataRequest : public FPlayFabRequestC
 public:
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Shared Group Data Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Key-value pairs to be written to the custom data. Note that keys are trimmed of whitespace, are limited in size, and may
      * not begin with a '!' character or be null.
      */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Shared Group Data Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
     /**
      * Optional list of Data-keys to remove from UserData. Some SDKs cannot insert null-values into Data due to language
      * constraints. Use this to delete the keys directly.
@@ -4063,7 +4063,7 @@ struct PLAYFAB_API FServerGetCatalogItemsResult : public FPlayFabResultCommon
 public:
     /** Array of items which can be purchased. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> Catalog;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Catalog;
 };
 
 /**
@@ -4089,7 +4089,7 @@ struct PLAYFAB_API FServerGetPublisherDataResult : public FPlayFabResultCommon
 public:
     /** a dictionary object of key / value pairs */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Title-Wide Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -4102,13 +4102,13 @@ public:
         FString CatalogVersion;
     /** Additional data about the store. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Title-Wide Data Management Models")
-        UPlayFabJsonObject* MarketingData = nullptr;
+        TObjectPtr<UPlayFabJsonObject> MarketingData;
     /** How the store was last updated (Admin or a third party). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Title-Wide Data Management Models")
         EPfSourceType Source = StaticCast<EPfSourceType>(0);
     /** Array of items which can be purchased from this store. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> Store;
+        TArray<TObjectPtr<UPlayFabJsonObject>> Store;
     /** The ID of this store. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Title-Wide Data Management Models")
         FString StoreId;
@@ -4135,7 +4135,7 @@ public:
         FString CatalogVersion;
     /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Title-Wide Data Management Models")
-        UPlayFabJsonObject* CustomTags = nullptr;
+        TObjectPtr<UPlayFabJsonObject> CustomTags;
     /**
      * Optional identifier for the player to use in requesting the store information - if used, segment overrides will be
      * applied
@@ -4200,7 +4200,7 @@ struct PLAYFAB_API FServerGetTitleDataResult : public FPlayFabResultCommon
 public:
     /** a dictionary object of key / value pairs */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Title-Wide Data Management Models")
-        UPlayFabJsonObject* Data = nullptr;
+        TObjectPtr<UPlayFabJsonObject> Data;
 };
 
 USTRUCT(BlueprintType)
@@ -4220,7 +4220,7 @@ struct PLAYFAB_API FServerGetTitleNewsResult : public FPlayFabResultCommon
 public:
     /** Array of localized news items. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Server | Title-Wide Data Management Models")
-        TArray<UPlayFabJsonObject*> News;
+        TArray<TObjectPtr<UPlayFabJsonObject>> News;
 };
 
 /**


### PR DESCRIPTION
Migrated raw pointer members to Unreal's new TObjectPtr<>. This fixes errors from UHT when building with native pointer member detection turned on.